### PR TITLE
Add required rustup components to rust-toolchain file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,9 @@ jobs:
         git config --global user.name "User"
         ./prepare.sh
 
+    - name: modified rust-toolchain to satisfy rustup version 1.20.1 in actions-rs
+      run: awk -F'[ ="]+' '$1 == "channel" { print $2 }' rust-toolchain > tmp && mv tmp rust-toolchain
+
     # Compile is a separate step, as the actions-rs/cargo action supports error annotations
     - name: Compile
       uses: actions-rs/cargo@v1.0.3

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash --verbose
 set -e
 
-rustup component add rust-src rustc-dev llvm-tools-preview
 ./build_sysroot/prepare_sysroot_src.sh

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2021-09-17
+[toolchain]
+channel = "nightly-2021-09-17"
+components = ["rust-src", "rustc-dev", "llvm-tools-preview"]


### PR DESCRIPTION
rustc_codegen_gcc and rust-clippy use same rustup components:

<https://github.com/rust-lang/rust-clippy/blob/master/rust-toolchain#L3>

move this code `rustup component add rust-src rustc-dev llvm-tools-preview` from `prepare.sh` to `rust-toolchain` is convenient for CI build (e.g. CI doesn't need to run prepare.sh before cargo test)

rust-toolchain file components require rustup minimal version [1.23.0 - 2020-11-27](https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#user-content-changed-3)

