### PR TITLE
Fix FIXME in `Builder::and` and `Builder::or` impls

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, ops::BitAnd};
+use std::borrow::Cow;
 use std::cell::Cell;
 use std::convert::TryFrom;
 use std::ops::Deref;


### PR DESCRIPTION
Since a bug in gccjit was resolved: https://gcc.gnu.org/bugzilla//show_bug.cgi?id=95498 the `Builder::and` and `Builder::or` impl can be fixed and made much cleaner.

I think I did this right? Is there a list somewhere with the proper casting rules? I was a able to run `./test.sh` and it made it through testing rust tests:
`test result: FAILED. 4352 passed; 86 failed; 50 ignored; 0 measured; 0 filtered out; finished in 93.79s`

closes #80