### PR TITLE
Remove unnecessary report_symbol_names call

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,6 @@ impl CodegenBackend for GccCodegenBackend {
         let target_cpu = target_cpu(tcx.sess);
         let res = codegen_crate(self.clone(), tcx, target_cpu.to_string(), metadata, need_metadata_module);
 
-        rustc_symbol_mangling::test::report_symbol_names(tcx);
-
         Box::new(res)
     }
 


### PR DESCRIPTION
rustc_interface already calls it for you.