### PR TITLE
Correctly import foreign statics

### DIFF
--- a/cargo.sh
+++ b/cargo.sh
@@ -8,7 +8,7 @@ pushd $(dirname "$0") >/dev/null
 source config.sh
 
 # read nightly compiler from rust-toolchain file
-TOOLCHAIN=$(cat rust-toolchain)
+TOOLCHAIN=$(cat rust-toolchain | grep channel | sed 's/channel = "\(.*\)"/\1/')
 
 popd >/dev/null
 

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash --verbose
 set -e
 
-rustup component add rust-src rustc-dev llvm-tools-preview
 ./build_sysroot/prepare_sysroot_src.sh

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-nightly-2021-12-30
+[toolchain]
+channel = "nightly-2021-12-30"
+components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,4 +1,4 @@
-use gccjit::{LValue, RValue, ToRValue, Type};
+use gccjit::{GlobalKind, LValue, RValue, ToRValue, Type};
 use rustc_codegen_ssa::traits::{BaseTypeMethods, ConstMethods, DerivedTypeMethods, StaticMethods};
 use rustc_hir as hir;
 use rustc_hir::Node;
@@ -218,7 +218,13 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
                         }
 
                         let is_tls = fn_attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL);
-                        let global = self.declare_global(&sym, llty, is_tls, fn_attrs.link_section);
+                        let global = self.declare_global(
+                            &sym,
+                            llty,
+                            GlobalKind::Exported,
+                            is_tls,
+                            fn_attrs.link_section,
+                        );
 
                         if !self.tcx.is_reachable_non_generic(def_id) {
                             // TODO(antoyo): set visibility.
@@ -389,6 +395,6 @@ fn check_and_apply_linkage<'gcc, 'tcx>(cx: &CodegenCx<'gcc, 'tcx>, attrs: &Codeg
         // don't do this then linker errors can be generated where the linker
         // complains that one object files has a thread local version of the
         // symbol and another one doesn't.
-        cx.declare_global(&sym, llty, is_tls, attrs.link_section)
+        cx.declare_global(&sym, llty, GlobalKind::Imported, is_tls, attrs.link_section)
     }
 }

--- a/src/declare.rs
+++ b/src/declare.rs
@@ -22,7 +22,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             global
         }
         else {
-            self.declare_global(name, ty, is_tls, link_section)
+            self.declare_global(name, ty, GlobalKind::Exported, is_tls, link_section)
         }
     }
 
@@ -47,8 +47,8 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         unsafe { std::mem::transmute(func) }
     }*/
 
-    pub fn declare_global(&self, name: &str, ty: Type<'gcc>, is_tls: bool, link_section: Option<Symbol>) -> LValue<'gcc> {
-        let global = self.context.new_global(None, GlobalKind::Exported, ty, name);
+    pub fn declare_global(&self, name: &str, ty: Type<'gcc>, global_kind: GlobalKind, is_tls: bool, link_section: Option<Symbol>) -> LValue<'gcc> {
+        let global = self.context.new_global(None, global_kind, ty, name);
         if is_tls {
             global.set_tls_model(self.tls_model);
         }

--- a/test.sh
+++ b/test.sh
@@ -145,7 +145,7 @@ function test_rustc() {
     echo
     echo "[TEST] rust-lang/rust"
 
-    rust_toolchain=$(cat rust-toolchain)
+    rust_toolchain=$(cat rust-toolchain | grep channel | sed 's/channel = "\(.*\)"/\1/')
 
     git clone https://github.com/rust-lang/rust.git || true
     cd rust

--- a/tests/run/assign.rs
+++ b/tests/run/assign.rs
@@ -51,7 +51,7 @@ mod libc {
         pub fn fflush(stream: *mut i32) -> i32;
         pub fn printf(format: *const i8, ...) -> i32;
 
-        pub static STDOUT: *mut i32;
+        pub static stdout: *mut i32;
     }
 }
 
@@ -67,7 +67,7 @@ mod intrinsics {
 pub fn panic(_msg: &str) -> ! {
     unsafe {
         libc::puts("Panicking\0" as *const str as *const u8);
-        libc::fflush(libc::STDOUT);
+        libc::fflush(libc::stdout);
         intrinsics::abort();
     }
 }

--- a/tests/run/int_overflow.rs
+++ b/tests/run/int_overflow.rs
@@ -49,7 +49,7 @@ mod libc {
         pub fn puts(s: *const u8) -> i32;
         pub fn fflush(stream: *mut i32) -> i32;
 
-        pub static STDOUT: *mut i32;
+        pub static stdout: *mut i32;
     }
 }
 
@@ -65,7 +65,7 @@ mod intrinsics {
 pub fn panic(_msg: &str) -> ! {
     unsafe {
         libc::puts("Panicking\0" as *const str as *const u8);
-        libc::fflush(libc::STDOUT);
+        libc::fflush(libc::stdout);
         intrinsics::abort();
     }
 }

--- a/tests/run/mut_ref.rs
+++ b/tests/run/mut_ref.rs
@@ -53,7 +53,7 @@ mod libc {
         pub fn fflush(stream: *mut i32) -> i32;
         pub fn printf(format: *const i8, ...) -> i32;
 
-        pub static STDOUT: *mut i32;
+        pub static stdout: *mut i32;
     }
 }
 
@@ -69,7 +69,7 @@ mod intrinsics {
 pub fn panic(_msg: &str) -> ! {
     unsafe {
         libc::puts("Panicking\0" as *const str as *const u8);
-        libc::fflush(libc::STDOUT);
+        libc::fflush(libc::stdout);
         intrinsics::abort();
     }
 }

--- a/tests/run/operations.rs
+++ b/tests/run/operations.rs
@@ -59,7 +59,7 @@ mod libc {
         pub fn puts(s: *const u8) -> i32;
         pub fn fflush(stream: *mut i32) -> i32;
 
-        pub static STDOUT: *mut i32;
+        pub static stdout: *mut i32;
     }
 }
 
@@ -75,7 +75,7 @@ mod intrinsics {
 pub fn panic(_msg: &str) -> ! {
     unsafe {
         libc::puts("Panicking\0" as *const str as *const u8);
-        libc::fflush(libc::STDOUT);
+        libc::fflush(libc::stdout);
         intrinsics::abort();
     }
 }


### PR DESCRIPTION
This is a fix for the environment variable issue I reported in a PM.

Previously foreign statics would actually cause a local static to be defined and exported. This issue was found because std::env::vars() was found to return no env vars despite many being defined. This was caused by libstd importing environ as foreign static. The accidental definition of environ caused libstd to read a null pointer which was interpreted as there being no environment variables at all.

I also move rustup component installation to rust-toolchain This allows cargo check to function correctly without having to first
run prepare_build.sh. cg_clif has been using rust-toolchain too for a while now.

