### PR TITLE
Support -Zfunction-sections

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -85,6 +85,12 @@ pub fn compile_codegen_unit<'tcx>(tcx: TyCtxt<'tcx>, cgu_name: Symbol) -> (Modul
         context.add_command_line_option("-fno-semantic-interposition");
         // NOTE: Rust relies on LLVM not doing TBAA (https://github.com/rust-lang/unsafe-code-guidelines/issues/292).
         context.add_command_line_option("-fno-strict-aliasing");
+
+        if tcx.sess.opts.debugging_opts.function_sections.unwrap_or(tcx.sess.target.function_sections) {
+            context.add_command_line_option("-ffunction-sections");
+            context.add_command_line_option("-fdata-sections");
+        }
+
         if env::var("CG_GCCJIT_DUMP_CODE").as_deref() == Ok("1") {
             context.set_dump_code_on_compile(true);
         }


### PR DESCRIPTION
This puts every function and data object in their own section. This allows the linker to omit unused functions and data objects with `--gc-sections`.

On linux this shrinks a hello world binary without optimizations (neither sysroot nor binary) from 17MB to 13MB. It shrinks a hello world binary with only sysroot optimizations from 14MB to 13MB. For comparison cg_llvm produces a 3.5MB debug mode hello world binary with an optimized sysroot. Cg_clif produces a 10MB debug mode hello world binary without an optimized sysroot.

Fixed https://github.com/rust-lang/rustc_codegen_gcc/issues/117