### PR TITLE
Support -Cpanic=unwind without unwinding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "gccjit"
 version = "1.0.0"
-source = "git+https://github.com/antoyo/gccjit.rs#cbb07c6601ba4246fc2967c4d770403c57192ca2"
+source = "git+https://github.com/antoyo/gccjit.rs#b9f188d2ce2c7b12211e90903f1b2cf309785b85"
 dependencies = [
  "gccjit_sys",
 ]
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "gccjit_sys"
 version = "0.0.1"
-source = "git+https://github.com/antoyo/gccjit.rs#cbb07c6601ba4246fc2967c4d770403c57192ca2"
+source = "git+https://github.com/antoyo/gccjit.rs#b9f188d2ce2c7b12211e90903f1b2cf309785b85"
 dependencies = [
  "libc 0.1.12",
 ]

--- a/src/base.rs
+++ b/src/base.rs
@@ -105,6 +105,9 @@ pub fn compile_codegen_unit<'tcx>(tcx: TyCtxt<'tcx>, cgu_name: Symbol, supports_
             context.set_keep_intermediates(true);
         }
 
+        // TODO(bjorn3): Remove once unwinding is properly implemented
+        context.set_allow_unreachable_blocks(true);
+
         {
             let cx = CodegenCx::new(&context, cgu, tcx, supports_128bit_integers);
 

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -1086,7 +1086,9 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
 }
 
 fn try_intrinsic<'gcc, 'tcx>(bx: &mut Builder<'_, 'gcc, 'tcx>, try_func: RValue<'gcc>, data: RValue<'gcc>, _catch_func: RValue<'gcc>, dest: RValue<'gcc>) {
-    if bx.sess().panic_strategy() == PanicStrategy::Abort {
+    // NOTE: the `|| true` here is to use the panic=abort strategy with panic=unwind too
+    if bx.sess().panic_strategy() == PanicStrategy::Abort || true {
+        // TODO(bjorn3): Properly implement unwinding and remove the `|| true` once this is done.
         bx.call(bx.type_void(), try_func, &[data], None);
         // Return 0 unconditionally from the intrinsic call;
         // we can never unwind.


### PR DESCRIPTION
This is necessary for bootstrapping rustc as compiling rustc with -Cpanic=abort is rather hard if at all possible. This does not implement actual unwinding on panics.