### PR TITLE
Fix the channel parameter passed to `build_sysroot.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,4 +36,9 @@ rm -r target/out || true
 mkdir -p target/out/gccjit
 
 echo "[BUILD] sysroot"
-time ./build_sysroot/build_sysroot.sh $CHANNEL
+if [[ "$CHANNEL" == "release" ]]; then
+    time ./build_sysroot/build_sysroot.sh --release
+else
+    time ./build_sysroot/build_sysroot.sh
+fi
+


### PR DESCRIPTION
`build_sysroot.sh` takes `--release`/(none), not `release`/`debug`.

https://github.com/rust-lang/rustc_codegen_gcc/blob/44c0204af3ac285474a779f777f0adc158a8344b/build_sysroot/build_sysroot.sh#L20-L26

(A certain architecture causes ICE when compiling without optimization due to [a bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96233) in GCC, hence this change is necessary.)