### PR TITLE
Add `--release-sysroot` flag to `build.sh`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,16 @@
 set -e
 
 codegen_channel=debug
+sysroot_channel=debug
 
 while [[ $# -gt 0 ]]; do
     case $1 in
         --release)
             codegen_channel=release
+            shift
+            ;;
+        --release-sysroot)
+            sysroot_channel=release
             shift
             ;;
         *)
@@ -51,5 +56,9 @@ rm -r target/out || true
 mkdir -p target/out/gccjit
 
 echo "[BUILD] sysroot"
-time ./build_sysroot/build_sysroot.sh $CHANNEL
+if [[ "$sysroot_channel" == "release" ]]; then
+    time ./build_sysroot/build_sysroot.sh --release
+else
+    time ./build_sysroot/build_sysroot.sh
+fi
 

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,21 @@
 #set -x
 set -e
 
+codegen_channel=debug
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --release)
+            codegen_channel=release
+            shift
+            ;;
+        *)
+            echo "Unknown option $1"
+            exit 1
+            ;;
+    esac
+done
+
 if [ -f ./gcc_path ]; then
     export GCC_PATH=$(cat gcc_path)
 else
@@ -21,7 +36,7 @@ if [[ "$1" == "--features" ]]; then
     shift
 fi
 
-if [[ "$1" == "--release" ]]; then
+if [[ "$codegen_channel" == "release" ]]; then
     export CHANNEL='release'
     CARGO_INCREMENTAL=1 cargo rustc --release $features
 else
@@ -37,3 +52,4 @@ mkdir -p target/out/gccjit
 
 echo "[BUILD] sysroot"
 time ./build_sysroot/build_sysroot.sh $CHANNEL
+


### PR DESCRIPTION
This PR adds a functionality to `build.sh` to build sysroot with optimization enabled, separately from the codegen. Supersedes #142.
