### PR TITLE
Don't pass --target in cargo.sh

### DIFF
--- a/cargo.sh
+++ b/cargo.sh
@@ -20,4 +20,4 @@ fi
 cmd=$1
 shift
 
-RUSTDOCFLAGS="$RUSTFLAGS" cargo +${TOOLCHAIN} $cmd --target $TARGET_TRIPLE $@
+RUSTDOCFLAGS="$RUSTFLAGS" cargo +${TOOLCHAIN} $cmd $@


### PR DESCRIPTION
This was a workaround for compiling proc macros resulting in an abi
incompatibility. By passing --target proc macros will be built by the
llvm backend. This is no longer necessary as the abi incompatibility has
since been fixed.