### PR TITLE
Add inline assembly `sym` operands as GCC input operands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ license = "MIT OR Apache-2.0"
 crate-type = ["dylib"]
 
 [[test]]
-name = "lang_tests"
-path = "tests/lib.rs"
+name = "lang_tests_debug"
+path = "tests/lang_tests_debug.rs"
+harness = false
+[[test]]
+name = "lang_tests_release"
+path = "tests/lang_tests_release.rs"
 harness = false
 
 [features]

--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -1,3 +1,4 @@
+//! The common code for `tests/lang_tests_*.rs`
 use std::{
     env::{self, current_dir},
     path::PathBuf,
@@ -7,7 +8,15 @@ use std::{
 use lang_tester::LangTester;
 use tempfile::TempDir;
 
-fn main() {
+/// Controls the compile options (e.g., optimization level) used to compile
+/// test code.
+#[allow(dead_code)] // Each test crate picks one variant
+pub enum Profile {
+    Debug,
+    Release,
+}
+
+pub fn main_inner(profile: Profile) {
     let tempdir = TempDir::new().expect("temp dir");
     let current_dir = current_dir().expect("current dir");
     let current_dir = current_dir.to_str().expect("current dir").to_string();
@@ -42,6 +51,15 @@ fn main() {
                 "-o", exe.to_str().expect("to_str"),
                 path.to_str().expect("to_str"),
             ]);
+            match profile {
+                Profile::Debug => {}
+                Profile::Release => {
+                    compiler.args(&[
+                        "-C", "opt-level=3",
+                        "-C", "lto=no",
+                    ]);
+                }
+            }
             // Test command 2: run `tempdir/x`.
             let runtime = Command::new(exe);
             vec![("Compiler", compiler), ("Run-time", runtime)]

--- a/tests/lang_tests_debug.rs
+++ b/tests/lang_tests_debug.rs
@@ -1,0 +1,5 @@
+mod lang_tests_common;
+
+fn main() {
+    lang_tests_common::main_inner(lang_tests_common::Profile::Debug);
+}

--- a/tests/lang_tests_release.rs
+++ b/tests/lang_tests_release.rs
@@ -1,0 +1,5 @@
+mod lang_tests_common;
+
+fn main() {
+    lang_tests_common::main_inner(lang_tests_common::Profile::Release);
+}


### PR DESCRIPTION
Updates `<Builder as AsmBuilderMethods>::codegen_inline_asm` to convert `sym` operands into GCC `"X" (&func_or_static)` input operands to indicate the dependency on the referenced symbols and prevent them from being eliminated.

Fixes #157.