### PR TITLE
Define immutable statics with const qualified types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "gccjit"
 version = "1.0.0"
-source = "git+https://github.com/antoyo/gccjit.rs#6c2af0cf733a26740f01a7c679afc20431165a54"
+source = "git+https://github.com/antoyo/gccjit.rs#bdb86fb5092895ff5589726b33250010c64d93f6"
 dependencies = [
  "gccjit_sys",
 ]
@@ -49,7 +49,7 @@ dependencies = [
 [[package]]
 name = "gccjit_sys"
 version = "0.0.1"
-source = "git+https://github.com/antoyo/gccjit.rs#6c2af0cf733a26740f01a7c679afc20431165a54"
+source = "git+https://github.com/antoyo/gccjit.rs#bdb86fb5092895ff5589726b33250010c64d93f6"
 dependencies = [
  "libc 0.1.12",
 ]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -47,7 +47,10 @@ impl<'gcc, 'tcx> StaticMethods for CodegenCx<'gcc, 'tcx> {
             }
         }
         let global_value = self.static_addr_of_mut(cv, align, kind);
-        // TODO(antoyo): set global constant.
+        #[cfg(feature = "master")]
+        self.global_lvalues.borrow().get(&global_value)
+            .expect("`static_addr_of_mut` did not add the global to `self.global_lvalues`")
+            .global_set_readonly();
         self.const_globals.borrow_mut().insert(cv, global_value);
         global_value
     }
@@ -88,7 +91,8 @@ impl<'gcc, 'tcx> StaticMethods for CodegenCx<'gcc, 'tcx> {
         // mutability are placed into read-only memory.
         if !is_mutable {
             if self.type_is_freeze(ty) {
-                // TODO(antoyo): set global constant.
+                #[cfg(feature = "master")]
+                global.global_set_readonly();
             }
         }
 


### PR DESCRIPTION
This PR adds `const` qualification to the types of immutable statics to allow them to be placed in a read-only section.

Fixes #161.

```rust
#[no_mangle]
pub extern "C" fn ultimate_answer_concise() -> u32 {
    const CANDIDATES: &[u32] = &[41, 42, 43];
    CANDIDATES[1]
}
```

```
Before:
    0000000000001100 <ultimate_answer>:
        1100:       48 8d 05 19 2f 00 00    lea    0x2f19(%rip),%rax        # 4020 <ultimate_answer_concise+0x2f10>
        1107:       c3                      ret
        1108:       0f 1f 84 00 00 00 00    nopl   0x0(%rax,%rax,1)
        110f:       00

After:
    0000000000001110 <ultimate_answer_concise>:
        1110:       b8 2a 00 00 00          mov    $0x2a,%eax
        1115:       c3
```
