### PR TITLE
simd: Implement missing reduction intrinsics

### DIFF
--- a/failing-ui-tests.txt
+++ b/failing-ui-tests.txt
@@ -40,7 +40,6 @@ src/test/ui/simd/intrinsic/generic-as.rs
 src/test/ui/simd/intrinsic/generic-bitmask-pass.rs
 src/test/ui/simd/intrinsic/generic-comparison-pass.rs
 src/test/ui/simd/intrinsic/generic-gather-pass.rs
-src/test/ui/simd/intrinsic/generic-reduction-pass.rs
 src/test/ui/simd/intrinsic/generic-select-pass.rs
 src/test/ui/simd/issue-17170.rs
 src/test/ui/simd/issue-39720.rs

--- a/failing-ui-tests12.txt
+++ b/failing-ui-tests12.txt
@@ -11,6 +11,7 @@ src/test/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pointer-width.rs
 src/test/ui/simd/intrinsic/generic-elements-pass.rs
+src/test/ui/simd/intrinsic/generic-reduction-pass.rs
 src/test/ui/simd/intrinsic/inlining-issue67557-ice.rs
 src/test/ui/simd/intrinsic/inlining-issue67557.rs
 src/test/ui/simd/monomorphize-shuffle-index.rs

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -247,10 +247,6 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
 
         self.context.new_array_type(None, ty, len)
     }
-
-    pub fn type_bool(&self) -> Type<'gcc> {
-        self.context.new_type::<bool>()
-    }
 }
 
 pub fn struct_fields<'gcc, 'tcx>(cx: &CodegenCx<'gcc, 'tcx>, layout: TyAndLayout<'tcx>) -> (Vec<Type<'gcc>>, bool) {


### PR DESCRIPTION
Implements the following simd reduction intrinsics:
- `simd_reduce_add_ordered`
- `simd_reduce_mul_ordered`
- `simd_reduce_min_nanless`
- `simd_reduce_max_nanless`
- `simd_reduce_xor`
- `simd_reduce_any`
- `simd_reduce_all`

Also fixes the ordering of `simd_reduce_min` and `simd_reduce_max`, which were tested to be flipped.

Both `simd_reduce_min_nanless` and `simd_reduce_max_nanless` are identical to their non-nanless variants for the time being.  An attempt was made at a more optimal codegen solution based on `vector_reduce_op`.  However, this approach ran into masking issues for floating-point vector types,which appears to be broken for the same reason that comparison operations such as `simd_lt` are broken for floating-point vector types.  More investigation is required, however, to determine a root cause and
appropriate fix.

This should be enough to pass the generic-reduction-pass.rs ui tests.
