### PR TITLE
setup: simplify build procedure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - uses: actions/checkout@v2
       with:
-        repository: llvm/llvm-project
-        path: llvm
+        recursive: true
 
     - name: Install packages
       run: sudo apt-get install ninja-build ripgrep
@@ -44,9 +41,6 @@ jobs:
         echo "LIBRARY_PATH=$(cat gcc_path)" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=$(cat gcc_path)" >> $GITHUB_ENV
         echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
-
-    - name: Set RUST_COMPILER_RT_ROOT
-      run: echo "RUST_COMPILER_RT_ROOT="${{ env.workspace }}/llvm/compiler-rt >> $GITHUB_ENV
 
     # https://github.com/actions/cache/issues/133
     - name: Fixup owner of ~/.cargo/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "llvm"]
+	path = llvm
+	url = https://github.com/llvm/llvm-project
+	branch = main

--- a/Readme.md
+++ b/Readme.md
@@ -19,10 +19,8 @@ You can also use my [fork of gcc](https://github.com/antoyo/gcc) which already i
 **Put the path to your custom build of libgccjit in the file `gcc_path`.**
 
 ```bash
-$ git clone https://github.com/rust-lang/rustc_codegen_gcc.git
+$ git clone https://github.com/rust-lang/rustc_codegen_gcc.git --recursive
 $ cd rustc_codegen_gcc
-$ git clone https://github.com/llvm/llvm-project llvm --depth 1 --single-branch
-$ export RUST_COMPILER_RT_ROOT="$PWD/llvm/compiler-rt"
 $ ./prepare_build.sh # download and patch sysroot src
 $ ./build.sh --release
 ```
@@ -57,12 +55,12 @@ $ rustc +$(cat $cg_gccjit_dir/rust-toolchain) -Cpanic=abort -Zcodegen-backend=$c
 ## Env vars
 
 <dl>
-    <dt>CG_GCCJIT_INCR_CACHE_DISABLED</dt>
-    <dd>Don't cache object files in the incremental cache. Useful during development of cg_gccjit
-    to make it possible to use incremental mode for all analyses performed by rustc without caching
-    object files when their content should have been changed by a change to cg_gccjit.</dd>
-    <dt>CG_GCCJIT_DISPLAY_CG_TIME</dt>
-    <dd>Display the time it took to perform codegen for a crate</dd>
+<dt>CG_GCCJIT_INCR_CACHE_DISABLED</dt>
+<dd>Don't cache object files in the incremental cache. Useful during development of cg_gccjit
+to make it possible to use incremental mode for all analyses performed by rustc without caching
+object files when their content should have been changed by a change to cg_gccjit.</dd>
+<dt>CG_GCCJIT_DISPLAY_CG_TIME</dt>
+<dd>Display the time it took to perform codegen for a crate</dd>
 </dl>
 
 ## Debugging
@@ -73,78 +71,78 @@ Sometimes, libgccjit will crash and output an error like this:
 during RTL pass: expand
 libgccjit.so: error: in expmed_mode_index, at expmed.h:249
 0x7f0da2e61a35 expmed_mode_index
-	../../../gcc/gcc/expmed.h:249
+../../../gcc/gcc/expmed.h:249
 0x7f0da2e61aa4 expmed_op_cost_ptr
-	../../../gcc/gcc/expmed.h:271
+../../../gcc/gcc/expmed.h:271
 0x7f0da2e620dc sdiv_cost_ptr
-	../../../gcc/gcc/expmed.h:540
+../../../gcc/gcc/expmed.h:540
 0x7f0da2e62129 sdiv_cost
-	../../../gcc/gcc/expmed.h:558
+    ../../../gcc/gcc/expmed.h:558
 0x7f0da2e73c12 expand_divmod(int, tree_code, machine_mode, rtx_def*, rtx_def*, rtx_def*, int)
-	../../../gcc/gcc/expmed.c:4335
+    ../../../gcc/gcc/expmed.c:4335
 0x7f0da2ea1423 expand_expr_real_2(separate_ops*, rtx_def*, machine_mode, expand_modifier)
-	../../../gcc/gcc/expr.c:9240
-0x7f0da2cd1a1e expand_gimple_stmt_1
-	../../../gcc/gcc/cfgexpand.c:3796
-0x7f0da2cd1c30 expand_gimple_stmt
-	../../../gcc/gcc/cfgexpand.c:3857
-0x7f0da2cd90a9 expand_gimple_basic_block
-	../../../gcc/gcc/cfgexpand.c:5898
-0x7f0da2cdade8 execute
-	../../../gcc/gcc/cfgexpand.c:6582
-```
+    ../../../gcc/gcc/expr.c:9240
+    0x7f0da2cd1a1e expand_gimple_stmt_1
+    ../../../gcc/gcc/cfgexpand.c:3796
+    0x7f0da2cd1c30 expand_gimple_stmt
+    ../../../gcc/gcc/cfgexpand.c:3857
+    0x7f0da2cd90a9 expand_gimple_basic_block
+    ../../../gcc/gcc/cfgexpand.c:5898
+    0x7f0da2cdade8 execute
+    ../../../gcc/gcc/cfgexpand.c:6582
+    ```
 
-To see the code which causes this error, call the following function:
+    To see the code which causes this error, call the following function:
 
-```c
-gcc_jit_context_dump_to_file(ctxt, "/tmp/output.c", 1 /* update_locations */)
-```
+    ```c
+    gcc_jit_context_dump_to_file(ctxt, "/tmp/output.c", 1 /* update_locations */)
+    ```
 
-This will create a C-like file and add the locations into the IR pointing to this C file.
-Then, rerun the program and it will output the location in the second line:
+    This will create a C-like file and add the locations into the IR pointing to this C file.
+    Then, rerun the program and it will output the location in the second line:
 
-```
-libgccjit.so: /tmp/something.c:61322:0: error: in expmed_mode_index, at expmed.h:249
-```
+    ```
+    libgccjit.so: /tmp/something.c:61322:0: error: in expmed_mode_index, at expmed.h:249
+    ```
 
-Or add a breakpoint to `add_error` in gdb and print the line number using:
+    Or add a breakpoint to `add_error` in gdb and print the line number using:
 
-```
-p loc->m_line
-p loc->m_filename->m_buffer
-```
+    ```
+    p loc->m_line
+    p loc->m_filename->m_buffer
+    ```
 
-To print a debug representation of a tree:
+    To print a debug representation of a tree:
 
-```c
-debug_tree(expr);
-```
+    ```c
+    debug_tree(expr);
+    ```
 
-To get the `rustc` command to run in `gdb`, add the `--verbose` flag to `cargo build`.
+    To get the `rustc` command to run in `gdb`, add the `--verbose` flag to `cargo build`.
 
 ### How to use a custom-build rustc
 
- * Build the stage2 compiler (`rustup toolchain link debug-current build/x86_64-unknown-linux-gnu/stage2`).
- * Clean and rebuild the codegen with `debug-current` in the file `rust-toolchain`.
+    * Build the stage2 compiler (`rustup toolchain link debug-current build/x86_64-unknown-linux-gnu/stage2`).
+    * Clean and rebuild the codegen with `debug-current` in the file `rust-toolchain`.
 
 ### How to use [mem-trace](https://github.com/antoyo/mem-trace)
 
-`rustc` needs to be built without `jemalloc` so that `mem-trace` can overload `malloc` since `jemalloc` is linked statically, so a `LD_PRELOAD`-ed library won't a chance to intercept the calls to `malloc`.
+    `rustc` needs to be built without `jemalloc` so that `mem-trace` can overload `malloc` since `jemalloc` is linked statically, so a `LD_PRELOAD`-ed library won't a chance to intercept the calls to `malloc`.
 
 ### How to build a cross-compiling libgccjit
 
 #### Building libgccjit
 
- * Follow these instructions: https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/ with the following changes:
- * Configure gcc with `../gcc/configure --enable-host-shared --disable-multilib --enable-languages=c,jit,c++ --disable-bootstrap --enable-checking=release --prefix=/opt/m68k-gcc/ --target=m68k-linux --without-headers`.
- * Some shells, like fish, don't define the environment variable `$MACHTYPE`.
- * Add `CFLAGS="-Wno-error=attributes -g -O2"` at the end of the configure command for building glibc (`CFLAGS="-Wno-error=attributes -Wno-error=array-parameter -Wno-error=stringop-overflow -Wno-error=array-bounds -g -O2"` for glibc 2.31, which is useful for Debian).
+    * Follow these instructions: https://preshing.com/20141119/how-to-build-a-gcc-cross-compiler/ with the following changes:
+    * Configure gcc with `../gcc/configure --enable-host-shared --disable-multilib --enable-languages=c,jit,c++ --disable-bootstrap --enable-checking=release --prefix=/opt/m68k-gcc/ --target=m68k-linux --without-headers`.
+    * Some shells, like fish, don't define the environment variable `$MACHTYPE`.
+    * Add `CFLAGS="-Wno-error=attributes -g -O2"` at the end of the configure command for building glibc (`CFLAGS="-Wno-error=attributes -Wno-error=array-parameter -Wno-error=stringop-overflow -Wno-error=array-bounds -g -O2"` for glibc 2.31, which is useful for Debian).
 
 #### Configuring rustc_codegen_gcc
 
- * Set `TARGET_TRIPLE="m68k-unknown-linux-gnu"` in config.sh.
- * Since rustc doesn't support this architecture yet, set it back to `TARGET_TRIPLE="mips-unknown-linux-gnu"` (or another target having the same attributes). Alternatively, create a [target specification file](https://book.avr-rust.com/005.1-the-target-specification-json-file.html) (note that the `arch` specified in this file must be supported by the rust compiler).
- * Set `linker='-Clinker=m68k-linux-gcc'`.
- * Set the path to the cross-compiling libgccjit in `gcc_path`.
- * Comment the line: `context.add_command_line_option("-masm=intel");` in src/base.rs.
- * (might not be necessary) Disable the compilation of libstd.so (and possibly libcore.so?).
+    * Set `TARGET_TRIPLE="m68k-unknown-linux-gnu"` in config.sh.
+    * Since rustc doesn't support this architecture yet, set it back to `TARGET_TRIPLE="mips-unknown-linux-gnu"` (or another target having the same attributes). Alternatively, create a [target specification file](https://book.avr-rust.com/005.1-the-target-specification-json-file.html) (note that the `arch` specified in this file must be supported by the rust compiler).
+    * Set `linker='-Clinker=m68k-linux-gcc'`.
+    * Set the path to the cross-compiling libgccjit in `gcc_path`.
+    * Comment the line: `context.add_command_line_option("-masm=intel");` in src/base.rs.
+    * (might not be necessary) Disable the compilation of libstd.so (and possibly libcore.so?).

--- a/config.sh
+++ b/config.sh
@@ -11,12 +11,12 @@ fi
 
 unamestr=`uname`
 if [[ "$unamestr" == 'Linux' ]]; then
-   dylib_ext='so'
+    dylib_ext='so'
 elif [[ "$unamestr" == 'Darwin' ]]; then
-   dylib_ext='dylib'
+    dylib_ext='dylib'
 else
-   echo "Unsupported os"
-   exit 1
+    echo "Unsupported os"
+    exit 1
 fi
 
 HOST_TRIPLE=$(rustc -vV | grep host | cut -d: -f2 | tr -d " ")
@@ -26,23 +26,23 @@ TARGET_TRIPLE=$HOST_TRIPLE
 linker=''
 RUN_WRAPPER=''
 if [[ "$HOST_TRIPLE" != "$TARGET_TRIPLE" ]]; then
-   if [[ "$TARGET_TRIPLE" == "m68k-unknown-linux-gnu" ]]; then
-       TARGET_TRIPLE="mips-unknown-linux-gnu"
-       linker='-Clinker=m68k-linux-gcc'
-   elif [[ "$TARGET_TRIPLE" == "aarch64-unknown-linux-gnu" ]]; then
-      # We are cross-compiling for aarch64. Use the correct linker and run tests in qemu.
-      linker='-Clinker=aarch64-linux-gnu-gcc'
-      RUN_WRAPPER='qemu-aarch64 -L /usr/aarch64-linux-gnu'
-   else
-      echo "Unknown non-native platform"
-   fi
+    if [[ "$TARGET_TRIPLE" == "m68k-unknown-linux-gnu" ]]; then
+        TARGET_TRIPLE="mips-unknown-linux-gnu"
+        linker='-Clinker=m68k-linux-gcc'
+    elif [[ "$TARGET_TRIPLE" == "aarch64-unknown-linux-gnu" ]]; then
+        # We are cross-compiling for aarch64. Use the correct linker and run tests in qemu.
+        linker='-Clinker=aarch64-linux-gnu-gcc'
+        RUN_WRAPPER='qemu-aarch64 -L /usr/aarch64-linux-gnu'
+    else
+        echo "Unknown non-native platform"
+    fi
 fi
 
 export RUSTFLAGS="$CG_RUSTFLAGS $linker -Cpanic=abort -Csymbol-mangling-version=v0 -Cdebuginfo=2 -Clto=off -Zpanic-abort-tests -Zcodegen-backend=$(pwd)/target/${CHANNEL:-debug}/librustc_codegen_gcc.$dylib_ext --sysroot $(pwd)/build_sysroot/sysroot"
 
 # FIXME(antoyo): remove once the atomic shim is gone
 if [[ `uname` == 'Darwin' ]]; then
-   export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
+    export RUSTFLAGS="$RUSTFLAGS -Clink-arg=-undefined -Clink-arg=dynamic_lookup"
 fi
 
 RUSTC="rustc $RUSTFLAGS -L crate=target/out --out-dir target/out"
@@ -50,3 +50,4 @@ export RUSTC_LOG=warn # display metadata load errors
 
 export LD_LIBRARY_PATH="$(pwd)/target/out:$(pwd)/build_sysroot/sysroot/lib/rustlib/$TARGET_TRIPLE/lib:$GCC_PATH"
 export DYLD_LIBRARY_PATH=$LD_LIBRARY_PATH
+export RUST_COMPILER_RT_ROOT="$PWD/llvm/compiler-rt"


### PR DESCRIPTION
removed redundant manual configuration of environment
added llvm as git submodule (requires recursive clone)

this PR aims to reduce the amount of manual configuration required to build this project. i am working on addressing https://github.com/rust-lang/rustc_codegen_gcc/issues/169 at the same time as well. also, the build setup seems a bit too complicated in general, trying to simplify.

for the moment this build will fail.