### PR TITLE
simd: implement simd_fmin/fmax

### DIFF
--- a/failing-ui-tests.txt
+++ b/failing-ui-tests.txt
@@ -32,7 +32,6 @@ src/test/ui/sepcomp/sepcomp-fns.rs
 src/test/ui/sepcomp/sepcomp-statics.rs
 src/test/ui/simd/generics.rs
 src/test/ui/simd/intrinsic/float-math-pass.rs
-src/test/ui/simd/intrinsic/float-minmax-pass.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-pass.rs
 src/test/ui/simd/intrinsic/generic-as.rs
 src/test/ui/simd/intrinsic/generic-bitmask-pass.rs

--- a/failing-ui-tests12.txt
+++ b/failing-ui-tests12.txt
@@ -8,6 +8,7 @@ src/test/ui/packed/packed-struct-size.rs
 src/test/ui/packed/packed-struct-vec.rs
 src/test/ui/packed/packed-tuple-struct-layout.rs
 src/test/ui/simd/array-type.rs
+src/test/ui/simd/intrinsic/float-minmax-pass.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pointer-width.rs

--- a/src/intrinsic/simd.rs
+++ b/src/intrinsic/simd.rs
@@ -492,6 +492,8 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(bx: &mut Builder<'a, 'gcc, 'tcx>, 
         simd_and: Uint, Int => and;
         simd_or: Uint, Int => or; // FIXME(antoyo): calling `or` might not work on vectors.
         simd_xor: Uint, Int => xor;
+        simd_fmin: Float => vector_fmin;
+        simd_fmax: Float => vector_fmax;
     }
 
     macro_rules! arith_unary {


### PR DESCRIPTION
This implements simd_fmin/fmax in a largely-optimal method.

Signed-off-by: Andy Sadler <andrewsadler122@gmail.com>