### PR TITLE
simd: impl extract_element for vector types

### DIFF
--- a/failing-ui-tests.txt
+++ b/failing-ui-tests.txt
@@ -30,12 +30,10 @@ src/test/ui/sepcomp/sepcomp-extern.rs
 src/test/ui/sepcomp/sepcomp-fns-backwards.rs
 src/test/ui/sepcomp/sepcomp-fns.rs
 src/test/ui/sepcomp/sepcomp-statics.rs
-src/test/ui/simd/generics.rs
 src/test/ui/simd/intrinsic/float-math-pass.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-pass.rs
 src/test/ui/simd/intrinsic/generic-as.rs
 src/test/ui/simd/intrinsic/generic-bitmask-pass.rs
-src/test/ui/simd/intrinsic/generic-comparison-pass.rs
 src/test/ui/simd/intrinsic/generic-gather-pass.rs
 src/test/ui/simd/intrinsic/generic-select-pass.rs
 src/test/ui/simd/issue-17170.rs

--- a/failing-ui-tests12.txt
+++ b/failing-ui-tests12.txt
@@ -12,6 +12,7 @@ src/test/ui/simd/intrinsic/float-minmax-pass.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pointer-width.rs
+src/test/ui/simd/intrinsic/generic-comparison-pass.rs
 src/test/ui/simd/intrinsic/generic-elements-pass.rs
 src/test/ui/simd/intrinsic/generic-reduction-pass.rs
 src/test/ui/simd/intrinsic/inlining-issue67557-ice.rs


### PR DESCRIPTION
This fixes some tests that needed vector element extraction.

Signed-off-by: Andy Sadler <andrewsadler122@gmail.com>