### PR TITLE
simd: implement float math intrinsics

### DIFF
--- a/failing-ui-tests.txt
+++ b/failing-ui-tests.txt
@@ -30,7 +30,6 @@ src/test/ui/sepcomp/sepcomp-extern.rs
 src/test/ui/sepcomp/sepcomp-fns-backwards.rs
 src/test/ui/sepcomp/sepcomp-fns.rs
 src/test/ui/sepcomp/sepcomp-statics.rs
-src/test/ui/simd/intrinsic/float-math-pass.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-pass.rs
 src/test/ui/simd/intrinsic/generic-as.rs
 src/test/ui/simd/intrinsic/generic-bitmask-pass.rs
@@ -40,7 +39,6 @@ src/test/ui/simd/issue-17170.rs
 src/test/ui/simd/issue-39720.rs
 src/test/ui/simd/issue-85915-simd-ptrs.rs
 src/test/ui/simd/issue-89193.rs
-src/test/ui/simd/libm_std_can_float.rs
 src/test/ui/simd/simd-bitmask.rs
 src/test/ui/simd/type-generic-monomorphisation-extern-nonnull-ptr.rs
 src/test/ui/sse2.rs


### PR DESCRIPTION
Implements the intrinsics required to pass float-math-pass and libm_std_can_float ui tests.

Signed-off-by: Andy Sadler <andrewsadler122@gmail.com>