### PR TITLE
simd: enable simd_as intrinsic

### DIFF
--- a/failing-ui-tests.txt
+++ b/failing-ui-tests.txt
@@ -31,7 +31,6 @@ src/test/ui/sepcomp/sepcomp-fns-backwards.rs
 src/test/ui/sepcomp/sepcomp-fns.rs
 src/test/ui/sepcomp/sepcomp-statics.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-pass.rs
-src/test/ui/simd/intrinsic/generic-as.rs
 src/test/ui/simd/intrinsic/generic-bitmask-pass.rs
 src/test/ui/simd/intrinsic/generic-gather-pass.rs
 src/test/ui/simd/intrinsic/generic-select-pass.rs

--- a/failing-ui-tests12.txt
+++ b/failing-ui-tests12.txt
@@ -10,6 +10,7 @@ src/test/ui/packed/packed-tuple-struct-layout.rs
 src/test/ui/simd/array-type.rs
 src/test/ui/simd/intrinsic/float-minmax-pass.rs
 src/test/ui/simd/intrinsic/generic-arithmetic-saturating-pass.rs
+src/test/ui/simd/intrinsic/generic-as.rs
 src/test/ui/simd/intrinsic/generic-cast-pass.rs
 src/test/ui/simd/intrinsic/generic-cast-pointer-width.rs
 src/test/ui/simd/intrinsic/generic-comparison-pass.rs

--- a/src/intrinsic/simd.rs
+++ b/src/intrinsic/simd.rs
@@ -254,7 +254,7 @@ pub fn generic_simd_intrinsic<'a, 'gcc, 'tcx>(bx: &mut Builder<'a, 'gcc, 'tcx>, 
     }
 
     #[cfg(feature="master")]
-    if name == sym::simd_cast {
+    if name == sym::simd_cast || name == sym::simd_as {
         require_simd!(ret_ty, "return");
         let (out_len, out_elem) = ret_ty.simd_size_and_type(bx.tcx());
         require!(


### PR DESCRIPTION
The method context.convert_vector, added to libgccjit for `simd_cast`, appears to give the correct behavior for `simd_as`.  Instead of special-casing `simd_as`, re-use `simd_cast`'s impl for `simd_as`.

Signed-off-by: Andy Sadler <andrewsadler122@gmail.com>