### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
         ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: llvm/llvm-project
         path: llvm
@@ -77,25 +77,25 @@ jobs:
       run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
 
     - name: Cache cargo installed crates
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/bin
         key: cargo-installed-crates2-ubuntu-latest
 
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry2-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo index
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo target dir
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('rust-toolchain') }}
@@ -103,7 +103,7 @@ jobs:
     - name: Cache rust repository
       # We only clone the rust repository for rustc tests
       if: ${{ contains(matrix.commands, 'rustc') }}
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       id: cache-rust-repository
       with:
         path: rust
@@ -140,5 +140,5 @@ jobs:
   duplicates:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: python tools/check_intrinsics_duplicates.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,6 @@ jobs:
     - name: Set RUST_COMPILER_RT_ROOT
       run: echo "RUST_COMPILER_RT_ROOT="${{ env.workspace }}/llvm/compiler-rt >> $GITHUB_ENV
 
-    # https://github.com/actions/cache/issues/133
-    - name: Fixup owner of ~/.cargo/
-      # Don't remove the trailing /. It is necessary to follow the symlink.
-      run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
-
     - name: Cache cargo installed crates
       uses: actions/cache@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,11 +58,6 @@ jobs:
     - name: Set RUST_COMPILER_RT_ROOT
       run: echo "RUST_COMPILER_RT_ROOT="${{ env.workspace }}/llvm/compiler-rt >> $GITHUB_ENV
 
-    # https://github.com/actions/cache/issues/133
-    - name: Fixup owner of ~/.cargo/
-      # Don't remove the trailing /. It is necessary to follow the symlink.
-      run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
-
     - name: Cache cargo installed crates
       uses: actions/cache@v3
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
           - { gcc: "libgccjit.so", artifacts_branch: "master" }
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: llvm/llvm-project
         path: llvm
@@ -64,25 +64,25 @@ jobs:
       run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
 
     - name: Cache cargo installed crates
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/bin
         key: cargo-installed-crates2-ubuntu-latest
 
     - name: Cache cargo registry
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/registry
         key: ${{ runner.os }}-cargo-registry2-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo index
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.cargo/git
         key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo target dir
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v3
       with:
         path: target
         key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('rust-toolchain') }}


### PR DESCRIPTION
Recent Github actions runs display the following warning:
```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout, actions/cache, actions/cache, actions/cache, actions/cache, actions-rs/cargo, actions/cache, actions/cache, actions/cache, actions/cache, actions/checkout, actions/checkout
```

This PR fixes this issue by bumping actions dependencies to use new releases based on node16.
This PR also remove cargo cache fixups that are not needed anymore.

The failing jobs (`--test-failing-rustc`) are the same as on main so not related to this PR.