### PR TITLE
Fix asm.rs test

### DIFF
--- a/tests/run/asm.rs
+++ b/tests/run/asm.rs
@@ -124,7 +124,7 @@ fn main() {
     // check const (ATT syntax)
     let mut x: u64 = 42;
     unsafe {
-        asm!("add {}, {}",
+        asm!("add ${}, {}",
             const 1,
             inout(reg) x,
             options(att_syntax)


### PR DESCRIPTION
`add 1, %rax` in AT&T syntax gets interpreted as `add rax, qword ptr [1]`. Use `$` to make it explicit that it is a constant rather than an address.