### PR TITLE
Add support for "ffi_const" function attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 [[package]]
 name = "gccjit"
 version = "1.0.0"
-source = "git+https://github.com/antoyo/gccjit.rs#de70a3bdc1908098ae4b10efc530bd695971a67c"
+source = "git+https://github.com/antoyo/gccjit.rs#61d8d55c894bd462ee66c096cc31157a44a9f869"
 dependencies = [
  "gccjit_sys",
 ]
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "gccjit_sys"
 version = "0.0.1"
-source = "git+https://github.com/antoyo/gccjit.rs#de70a3bdc1908098ae4b10efc530bd695971a67c"
+source = "git+https://github.com/antoyo/gccjit.rs#61d8d55c894bd462ee66c096cc31157a44a9f869"
 dependencies = [
  "libc",
 ]

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -124,6 +124,9 @@ pub fn from_fn_attrs<'gcc, 'tcx>(
         if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::FFI_PURE) {
             func.add_attribute(FnAttribute::Pure);
         }
+        if codegen_fn_attrs.flags.contains(CodegenFnAttrFlags::FFI_CONST) {
+            func.add_attribute(FnAttribute::Const);
+        }
     }
 
     let function_features =


### PR DESCRIPTION
Depends on https://github.com/antoyo/gcc/pull/22 and on https://github.com/antoyo/gccjit.rs/pull/21.

Will also need to update gccjit dependency once merged.