### PR TITLE
Honor `$RUSTUP_HOME`

### DIFF
--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -527,7 +527,7 @@ fn setup_rustc(env: &mut Env, args: &TestArg) -> Result<(), String> {
         }
     })?;
     let rustc = String::from_utf8(
-        run_command_with_env(&[&"rustup", &OsStr::new(&*toolchain), &"which", &"rustc"], rust_dir, Some(env))?.stdout,
+        run_command_with_env(&[&"rustup", &toolchain, &"which", &"rustc"], rust_dir, Some(env))?.stdout,
     )
     .map_err(|error| format!("Failed to retrieve rustc path: {:?}", error))
     .and_then(|rustc| {

--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -556,7 +556,7 @@ verbose-tests = true
 [build]
 cargo = "{cargo}"
 local-rebuild = true
-rustc = "{home}/.rustup/toolchains/{toolchain}-{host_triple}/bin/rustc"
+rustc = "{rustup_home}/toolchains/{toolchain}-{host_triple}/bin/rustc"
 
 [target.x86_64-unknown-linux-gnu]
 llvm-filecheck = "{llvm_filecheck}"
@@ -565,7 +565,10 @@ llvm-filecheck = "{llvm_filecheck}"
 download-ci-llvm = false
 "#,
             cargo = cargo.trim(),
-            home = env.get("HOME").unwrap(),
+            rustup_home = match env.get("RUSTUP_HOME") {
+                Some(rustup_dir) => rustup_dir.clone(),
+                None => env.get("HOME").unwrap().to_owned() + "/.rustup",
+            },
             toolchain = toolchain,
             host_triple = args.config_info.host_triple,
             llvm_filecheck = llvm_filecheck.trim(),


### PR DESCRIPTION
`build_system/src/test.rs` generates a `config.toml` that contains a path directly to (what should be) the appropriate rustc binary. However, it incorrectly assumed rustup stores the rustc binaries in `~/.rustup`. In actuality, rustup first checks the [environment variable](https://rust-lang.github.io/rustup/environment-variables.html) `RUSTUP_HOME`, and defaults to `~/.rustup` if the variable is not set. Now `build_system/src/test.rs` uses the correct path.

If there is a more idiomatic way to encode this please let me know and I'll fix it.