### PR TITLE
Revert "Use shallow clone in test.rs to reduce cloning overhead"

### DIFF
--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -499,41 +499,16 @@ fn setup_rustc(env: &mut Env, args: &TestArg) -> Result<PathBuf, String> {
             &"clone",
             &"https://github.com/rust-lang/rust.git",
             &rust_dir_path,
-            &"--depth",
-            &"1",
         ],
         None,
         Some(env),
     );
     let rust_dir: Option<&Path> = Some(&rust_dir_path);
     run_command(&[&"git", &"checkout", &"--", &"tests/"], rust_dir)?;
+    run_command_with_output_and_env(&[&"git", &"fetch"], rust_dir, Some(env))?;
     let rustc_commit = match rustc_version_info(env.get("RUSTC").map(|s| s.as_str()))?.commit_hash {
         Some(commit_hash) => commit_hash,
         None => return Err("Couldn't retrieve rustc commit hash".to_string()),
-    };
-    let has_commit = {
-        if let Ok(ty) = run_command_with_env(
-            &[&"git", &"cat-file", &"-t", &rustc_commit.as_str()],
-            rust_dir,
-            Some(env),
-        ) {
-            String::from_utf8_lossy(&ty.stdout).to_string() == "commit"
-        } else {
-            false
-        }
-    };
-    if !has_commit {
-        run_command_with_output_and_env(
-            &[
-                &"git",
-                &"fetch",
-                &"https://github.com/rust-lang/rust.git",
-                &rustc_commit.as_str(),
-                &"--depth=1",
-            ],
-            rust_dir,
-            Some(env),
-        )?
     };
     if rustc_commit != "unknown" {
         run_command_with_output_and_env(


### PR DESCRIPTION
Reverts rust-lang/rustc_codegen_gcc#432

After further discussions with @antoyo, we came to the conclusion that rather than using extra complex commands, downloading the whole git history was taking more disk space but was simpler to maintain as a whole. Like I said, I'm not a big fan of `--depth` because of issues I encountered with it in the past too so at least it's always that off my mind.

Thanks in  any case @tempdragon!