### PR TITLE
fix tests/ui/simd/issue-89193.rs and mark as passing

### DIFF
--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -48,7 +48,6 @@ tests/ui/rfcs/rfc-1857-stabilize-drop-order/drop-order.rs
 tests/ui/rfcs/rfc-2091-track-caller/std-panic-locations.rs
 tests/ui/simd/issue-17170.rs
 tests/ui/simd/issue-39720.rs
-tests/ui/simd/issue-89193.rs
 tests/ui/statics/issue-91050-1.rs
 tests/ui/statics/issue-91050-2.rs
 tests/ui/alloc-error/default-alloc-error-hook.rs

--- a/tests/failing-ui-tests12.txt
+++ b/tests/failing-ui-tests12.txt
@@ -33,6 +33,7 @@ tests/ui/coroutine/size-moved-locals.rs
 tests/ui/macros/rfc-2011-nicer-assert-messages/all-not-available-cases.rs
 tests/ui/simd/intrinsic/generic-gather-pass.rs
 tests/ui/simd/issue-85915-simd-ptrs.rs
+tests/ui/simd/issue-89193.rs
 tests/ui/issues/issue-68010-large-zst-consts.rs
 tests/ui/rust-2018/proc-macro-crate-in-paths.rs
 tests/ui/target-feature/missing-plusminus.rs


### PR DESCRIPTION
Work around an issue where usize and isize can sometimes (but not always) get canonicalized to their corresponding integer type.  This causes shuffle_vector to panic, since the types of the vectors it got passed aren't the same.

Also insert a cast on the mask element, since we might get passed a signed integer of any size, not just i32.  For now, we always cast to i32.