### PR TITLE
feat(Cargo.toml): Set `rustc_private` to `true` to allow lsp parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,3 +57,6 @@ debug = false
 [profile.release.build-override]
 opt-level = 0
 debug = false
+
+[package.metadata.rust-analyzer]
+rustc_private = true


### PR DESCRIPTION
Based on the comments in #428, it may be a good idea to add this option to `Cargo.toml` .
Hopefully I didn't misunderstand the suggestions from @antoyo & @sadlerap .
Thanks in advance.