### PR TITLE
fix(fmt/style): Clippy-generated Code Correction

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -63,7 +63,7 @@ pub(crate) unsafe fn codegen(
         tcx,
         context,
         "__rust_alloc_error_handler",
-        &alloc_error_handler_name(alloc_error_handler_kind),
+        alloc_error_handler_name(alloc_error_handler_kind),
         &[usize, usize],
         None,
     );
@@ -93,7 +93,7 @@ fn create_wrapper_function(
     let args: Vec<_> = types
         .iter()
         .enumerate()
-        .map(|(index, typ)| context.new_parameter(None, *typ, &format!("param{}", index)))
+        .map(|(index, typ)| context.new_parameter(None, *typ, format!("param{}", index)))
         .collect();
     let func = context.new_function(
         None,
@@ -115,7 +115,7 @@ fn create_wrapper_function(
     let args: Vec<_> = types
         .iter()
         .enumerate()
-        .map(|(index, typ)| context.new_parameter(None, *typ, &format!("param{}", index)))
+        .map(|(index, typ)| context.new_parameter(None, *typ, format!("param{}", index)))
         .collect();
     let callee = context.new_function(
         None,

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -96,7 +96,7 @@ impl AsmOutOperand<'_, '_, '_> {
             res.push('&');
         }
 
-        res.push_str(&self.constraint);
+        res.push_str(self.constraint);
         res
     }
 }
@@ -304,7 +304,7 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                         tmp_var.set_register_name(reg_name);
 
                         outputs.push(AsmOutOperand {
-                            constraint: "r".into(),
+                            constraint: "r",
                             rust_idx,
                             late,
                             readwrite: false,
@@ -343,7 +343,7 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                         tmp_var.set_register_name(reg_name);
 
                         outputs.push(AsmOutOperand {
-                            constraint: "r".into(),
+                            constraint: "r",
                             rust_idx,
                             late,
                             readwrite: false,

--- a/src/back/lto.rs
+++ b/src/back/lto.rs
@@ -106,11 +106,10 @@ fn prepare_lto(
             if !crate_type_allows_lto(*crate_type) {
                 dcx.emit_err(LtoDisallowed);
                 return Err(FatalError);
-            } else if *crate_type == CrateType::Dylib {
-                if !cgcx.opts.unstable_opts.dylib_lto {
-                    dcx.emit_err(LtoDylib);
-                    return Err(FatalError);
-                }
+            }
+            if *crate_type == CrateType::Dylib && !cgcx.opts.unstable_opts.dylib_lto {
+                dcx.emit_err(LtoDylib);
+                return Err(FatalError);
             }
         }
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -77,10 +77,8 @@ impl<'gcc, 'tcx> StaticMethods for CodegenCx<'gcc, 'tcx> {
         // boolean SSA values are i1, but they have to be stored in i8 slots,
         // otherwise some LLVM optimization passes don't work as expected
         let val_llty = self.val_ty(value);
-        let value = if val_llty == self.type_i1() {
+        if val_llty == self.type_i1() {
             unimplemented!();
-        } else {
-            value
         };
 
         let instance = Instance::mono(self.tcx, def_id);
@@ -94,11 +92,9 @@ impl<'gcc, 'tcx> StaticMethods for CodegenCx<'gcc, 'tcx> {
 
         // As an optimization, all shared statics which do not have interior
         // mutability are placed into read-only memory.
-        if !is_mutable {
-            if self.type_is_freeze(ty) {
-                #[cfg(feature = "master")]
-                global.global_set_readonly();
-            }
+        if !is_mutable && self.type_is_freeze(ty) {
+            #[cfg(feature = "master")]
+            global.global_set_readonly();
         }
 
         if attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL) {

--- a/src/debuginfo.rs
+++ b/src/debuginfo.rs
@@ -255,7 +255,6 @@ impl<'gcc, 'tcx> DebugInfoMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         _variable_kind: VariableKind,
         _span: Span,
     ) -> Self::DIVariable {
-        ()
     }
 
     fn dbg_scope_fn(

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -1065,7 +1065,7 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
 
             // Return `result_type`'s maximum or minimum value on overflow
             // NOTE: convert the type to unsigned to have an unsigned shift.
-            let unsigned_type = result_type.to_unsigned(&self.cx);
+            let unsigned_type = result_type.to_unsigned(self.cx);
             let shifted = self.gcc_lshr(
                 self.gcc_int_cast(lhs, unsigned_type),
                 self.gcc_int(unsigned_type, width as i64 - 1),
@@ -1108,9 +1108,10 @@ fn try_intrinsic<'a, 'b, 'gcc, 'tcx>(
         // we can never unwind.
         let ret_align = bx.tcx.data_layout.i32_align.abi;
         bx.store(bx.const_i32(0), dest, ret_align);
-    } else if wants_msvc_seh(bx.sess()) {
-        unimplemented!();
     } else {
+        if wants_msvc_seh(bx.sess()) {
+            unimplemented!();
+        }
         #[cfg(feature = "master")]
         codegen_gnu_try(bx, try_func, data, _catch_func, dest);
         #[cfg(not(feature = "master"))]
@@ -1160,7 +1161,7 @@ fn codegen_gnu_try<'gcc>(
         let catch_func = func.get_param(2).to_rvalue();
         let try_func_ty = bx.type_func(&[bx.type_i8p()], bx.type_void());
 
-        let current_block = bx.block.clone();
+        let current_block = bx.block;
 
         bx.switch_to_block(then);
         bx.ret(bx.const_i32(0));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl CodegenBackend for GccCodegenBackend {
             // Get the second TargetInfo with the correct CPU features by setting the arch.
             let context = Context::default();
             if target_cpu != "generic" {
-                context.add_command_line_option(&format!("-march={}", target_cpu));
+                context.add_command_line_option(format!("-march={}", target_cpu));
             }
 
             **self.target_info.info.lock().expect("lock") = context.get_target_info();
@@ -224,9 +224,9 @@ impl CodegenBackend for GccCodegenBackend {
         providers.global_backend_features = |tcx, ()| gcc_util::global_gcc_features(tcx.sess, true)
     }
 
-    fn codegen_crate<'tcx>(
+    fn codegen_crate(
         &self,
-        tcx: TyCtxt<'tcx>,
+        tcx: TyCtxt<'_>,
         metadata: EncodedMetadata,
         need_metadata_module: bool,
     ) -> Box<dyn Any> {
@@ -292,9 +292,9 @@ fn new_context<'gcc, 'tcx>(tcx: TyCtxt<'tcx>) -> Context<'gcc> {
 }
 
 impl ExtraBackendMethods for GccCodegenBackend {
-    fn codegen_allocator<'tcx>(
+    fn codegen_allocator(
         &self,
-        tcx: TyCtxt<'tcx>,
+        tcx: TyCtxt<'_>,
         module_name: &str,
         kind: AllocatorKind,
         alloc_error_handler_kind: AllocatorKind,
@@ -486,6 +486,6 @@ pub fn target_features(
               sha, sse, sse2, sse3, sse4.1, sse4.2, sse4a, ssse3, tbm, vaes, vpclmulqdq, xsave, xsavec, xsaveopt, xsaves
             */
         })
-        .map(|feature| Symbol::intern(feature))
+        .map(Symbol::intern)
         .collect()
 }

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -47,7 +47,7 @@ impl<'gcc, 'tcx> PreDefineMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
 
         let fn_abi = self.fn_abi_of_instance(instance, ty::List::empty());
         self.linkage.set(base::linkage_to_gcc(linkage));
-        let decl = self.declare_fn(symbol_name, &fn_abi);
+        let decl = self.declare_fn(symbol_name, fn_abi);
         //let attrs = self.tcx.codegen_fn_attrs(instance.def_id());
 
         attributes::from_fn_attrs(self, decl, instance);

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -133,13 +133,13 @@ impl<'gcc, 'tcx> BaseTypeMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
     fn type_struct(&self, fields: &[Type<'gcc>], packed: bool) -> Type<'gcc> {
         let types = fields.to_vec();
         if let Some(typ) = self.struct_types.borrow().get(fields) {
-            return typ.clone();
+            return *typ;
         }
         let fields: Vec<_> = fields
             .iter()
             .enumerate()
             .map(|(index, field)| {
-                self.context.new_field(None, *field, &format!("field{}_TODO", index))
+                self.context.new_field(None, *field, format!("field{}_TODO", index))
             })
             .collect();
         let typ = self.context.new_struct_type(None, "struct", &fields).as_type();
@@ -240,7 +240,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         let fields: Vec<_> = fields
             .iter()
             .enumerate()
-            .map(|(index, field)| self.context.new_field(None, *field, &format!("field_{}", index)))
+            .map(|(index, field)| self.context.new_field(None, *field, format!("field_{}", index)))
             .collect();
         typ.set_fields(None, &fields);
         if packed {
@@ -265,7 +265,7 @@ pub fn struct_fields<'gcc, 'tcx>(
     let mut prev_effective_align = layout.align.abi;
     let mut result: Vec<_> = Vec::with_capacity(1 + field_count * 2);
     for i in layout.fields.index_by_increasing_offset() {
-        let target_offset = layout.fields.offset(i as usize);
+        let target_offset = layout.fields.offset(i);
         let field = layout.field(cx, i);
         let effective_field_align =
             layout.align.abi.min(field.align.abi).restrict_for_offset(target_offset);

--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -75,7 +75,7 @@ pub fn main_inner(profile: Profile) {
             exe.push(&tempdir);
             exe.push(path.file_stem().expect("file_stem"));
             let mut compiler = Command::new("rustc");
-            compiler.args(&[
+            compiler.args([
                 &format!("-Zcodegen-backend={}/target/debug/librustc_codegen_gcc.so", current_dir),
                 "--sysroot",
                 &format!("{}/build_sysroot/sysroot/", current_dir),
@@ -90,7 +90,7 @@ pub fn main_inner(profile: Profile) {
             // TODO(antoyo): find a way to send this via a cli argument.
             let test_target = std::env::var("CG_GCC_TEST_TARGET");
             if let Ok(ref target) = test_target {
-                compiler.args(&["--target", &target]);
+                compiler.args(["--target", target]);
                 let linker = format!("{}-gcc", target);
                 compiler.args(&[format!("-Clinker={}", linker)]);
                 let mut env_path = std::env::var("PATH").unwrap_or_default();
@@ -101,32 +101,32 @@ pub fn main_inner(profile: Profile) {
 
             if let Some(flags) = option_env!("TEST_FLAGS") {
                 for flag in flags.split_whitespace() {
-                    compiler.arg(&flag);
+                    compiler.arg(flag);
                 }
             }
             match profile {
                 Profile::Debug => {}
                 Profile::Release => {
-                    compiler.args(&["-C", "opt-level=3", "-C", "lto=no"]);
+                    compiler.args(["-C", "opt-level=3", "-C", "lto=no"]);
                 }
             }
             // Test command 2: run `tempdir/x`.
             if test_target.is_ok() {
                 let vm_parent_dir = std::env::var("CG_GCC_VM_DIR")
-                    .map(|dir| PathBuf::from(dir))
+                    .map(PathBuf::from)
                     .unwrap_or_else(|_| std::env::current_dir().unwrap());
                 let vm_dir = "vm";
                 let exe_filename = exe.file_name().unwrap();
                 let vm_home_dir = vm_parent_dir.join(vm_dir).join("home");
                 let vm_exe_path = vm_home_dir.join(exe_filename);
                 // FIXME(antoyo): panicking here makes the test pass.
-                let inside_vm_exe_path = PathBuf::from("/home").join(&exe_filename);
+                let inside_vm_exe_path = PathBuf::from("/home").join(exe_filename);
                 let mut copy = Command::new("sudo");
                 copy.arg("cp");
-                copy.args(&[&exe, &vm_exe_path]);
+                copy.args([&exe, &vm_exe_path]);
 
                 let mut runtime = Command::new("sudo");
-                runtime.args(&["chroot", vm_dir, "qemu-m68k-static"]);
+                runtime.args(["chroot", vm_dir, "qemu-m68k-static"]);
                 runtime.arg(inside_vm_exe_path);
                 runtime.current_dir(vm_parent_dir);
                 vec![("Compiler", compiler), ("Copy", copy), ("Run-time", runtime)]


### PR DESCRIPTION
NOTE: This is generated by `cargo clippy --fix --allow-dirty  -- -D --warnings `, and warnings are ignored by the clippy.

To pass the whole clippy test, more work is needed. For consistency, you may as well generate one yourself and then fix the warnings in your series.

// This is probably my last commit to cg_gcc in a month. Happy coding!