### PR TITLE
Fix configure path in the README.md instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -36,7 +36,7 @@ $ git clone https://github.com/antoyo/gcc
 $ sudo apt install flex libmpfr-dev libgmp-dev libmpc3 libmpc-dev
 $ mkdir gcc-build gcc-install
 $ cd gcc-build
-$ ../gcc/configure \
+$ ../configure \
     --enable-host-shared \
     --enable-languages=jit \
     --enable-checking=release \ # it enables extra checks which allow to find bugs


### PR DESCRIPTION
Using `gcc/configure` gives me a "no rule to make target"  error, the same as https://gcc.gnu.org/bugzilla/show_bug.cgi?id=25543. Using `/configure` seems to work correctly, hence this change.