### PR TITLE
Modify build_system's prepare stage to allow for custom sysroot source path

### DIFF
--- a/doc/tips.md
+++ b/doc/tips.md
@@ -35,6 +35,14 @@ COLLECT_NO_DEMANGLE=1
  * Build the stage2 compiler (`rustup toolchain link debug-current build/x86_64-unknown-linux-gnu/stage2`).
  * Clean and rebuild the codegen with `debug-current` in the file `rust-toolchain`.
 
+### How to use a custom sysroot source path
+
+If you wish to build a custom sysroot, pass the path of your sysroot source to `--sysroot-source` during the `prepare` step, like so:
+
+```
+./y.sh prepare --sysroot-source /path/to/custom/source
+```
+
 ### How to use [mem-trace](https://github.com/antoyo/mem-trace)
 
 `rustc` needs to be built without `jemalloc` so that `mem-trace` can overload `malloc` since `jemalloc` is linked statically, so a `LD_PRELOAD`-ed library won't a chance to intercept the calls to `malloc`.


### PR DESCRIPTION
This change allows users to specify a custom directory from which to copy the sysroot source code instead of being forced to use the `rust-src` provided with the `rustup` toolchain. The path is passed to `--sysroot-source` during the `prepare` stage, like so:

```
./y.sh prepare --sysroot-source /path/to/custom/source
```

This removes a pain point for using rustc_codegen_gcc while creating and testing support for new platforms with architectures without LLVM support.