### PR TITLE
simd: implement pointer provenance intrinsics

### DIFF
--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -33,7 +33,6 @@ tests/ui/panic-runtime/abort.rs
 tests/ui/panic-runtime/link-to-abort.rs
 tests/ui/unwind-no-uwtable.rs
 tests/ui/parser/unclosed-delimiter-in-dep.rs
-tests/ui/simd/intrinsic/ptr-cast.rs
 tests/ui/consts/missing_span_in_backtrace.rs
 tests/ui/drop/dynamic-drop.rs
 tests/ui/issues/issue-40883.rs


### PR DESCRIPTION
This adds support for the simd variants of the pointer provenance intrinsics, which are `simd_cast_ptr`, `simd_expose_addr`, and `simd_from_exposed_addr`.

The preconditions for each intrinsic are adapted from `rustc_codegen_llvm` to preserve compatibility.  Each of these intrinsics are implemented as calling the non-simd variant of each intrinsic on each lane.

This is enough to enable the UI test `ui/simd/intrinsic/ptr-cast.rs` to pass.