### PR TITLE
prevent libgccjit.so download on unsupported os/arch

### DIFF
--- a/build_system/src/config.rs
+++ b/build_system/src/config.rs
@@ -474,6 +474,19 @@ fn download_gccjit(
     tempfile_name: String,
     with_progress_bar: bool,
 ) -> Result<(), String> {
+    if std::env::consts::OS != "linux" || std::env::consts::ARCH != "x86_64" {
+        eprintln!(
+            "\
+        pre-compiled libgccjit.so not available for this os or architecture\n\
+        please compile it yourself and in the config.toml set\n\
+        `download-gccjit = false` and `gcc-path` to the appropriate directory\
+        "
+        );
+        return Err(String::from(
+            "no appropriate pre-compiled libgccjit.so available for download",
+        ));
+    }
+
     // Try curl. If that fails and we are on windows, fallback to PowerShell.
     let mut ret = run_command_with_output(
         &[

--- a/build_system/src/config.rs
+++ b/build_system/src/config.rs
@@ -473,9 +473,9 @@ fn download_gccjit(
     } else {
         eprintln!(
             "\
-        pre-compiled libgccjit.so not available for this os or architecture\n\
-        please compile it yourself and in the config.toml set\n\
-        `download-gccjit = false` and `gcc-path` to the appropriate directory\
+        Pre-compiled libgccjit.so not available for this os or architecture.\n\
+        Please compile it yourself and update the `config.toml` file\n\
+        to `download-gccjit = false` and set `gcc-path` to the appropriate directory.\
         "
         );
         return Err(String::from(

--- a/build_system/src/config.rs
+++ b/build_system/src/config.rs
@@ -473,10 +473,9 @@ fn download_gccjit(
     } else {
         eprintln!(
             "\
-        Pre-compiled libgccjit.so not available for this os or architecture.\n\
-        Please compile it yourself and update the `config.toml` file\n\
-        to `download-gccjit = false` and set `gcc-path` to the appropriate directory.\
-        "
+Pre-compiled libgccjit.so not available for this os or architecture.
+Please compile it yourself and update the `config.toml` file
+to `download-gccjit = false` and set `gcc-path` to the appropriate directory."
         );
         return Err(String::from(
             "no appropriate pre-compiled libgccjit.so available for download",

--- a/build_system/src/config.rs
+++ b/build_system/src/config.rs
@@ -232,7 +232,7 @@ impl ConfigInfo {
             let is_in_ci = std::env::var("GITHUB_ACTIONS").is_ok();
 
             let url = format!(
-                "https://github.com/antoyo/gcc/releases/download/master-{}/libgccjit.so",
+                "https://github.com/rust-lang/gcc/releases/download/master-{}/libgccjit.so",
                 commit,
             );
 


### PR DESCRIPTION
Alternative to #528, I find it easier to show what I meant rather than tell.

Fixing up the download URL while at it. 

fixes #527 