### PR TITLE
Make globals always have 2+ chars as suffix

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -606,7 +606,10 @@ impl<'b, 'tcx> CodegenCx<'b, 'tcx> {
         let mut name = String::with_capacity(prefix.len() + 6);
         name.push_str(prefix);
         name.push('.');
-        name.push_str(&(idx as u64).to_base(ALPHANUMERIC_ONLY));
+        // Offset the index by the base so that always at least two characters
+        // are generated. This avoids cases where the suffix is interpreted as
+        // size by the assembler (for m68k: .b, .w, .l).
+        name.push_str(&(idx as u64 + ALPHANUMERIC_ONLY as u64).to_base(ALPHANUMERIC_ONLY));
         name
     }
 }


### PR DESCRIPTION
As discussed on chat, there currently is the bug where certain suffixes are interpreted by the (m68k) assembler.

Example: `move.l #global.w,-44(%fp)`
`.w` is interpreted by the assembler as a size hint for #global.