### PR TITLE
Remove duplicated CI triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  - push
   - pull_request
 
 permissions:

--- a/.github/workflows/gcc12.yml
+++ b/.github/workflows/gcc12.yml
@@ -1,7 +1,6 @@
 name: CI libgccjit 12
 
 on:
-  - push
   - pull_request
 
 permissions:

--- a/.github/workflows/m68k.yml
+++ b/.github/workflows/m68k.yml
@@ -3,7 +3,6 @@
 name: m68k CI
 
 on:
-  - push
   - pull_request
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: CI with sysroot compiled in release mode
 
 on:
-  - push
   - pull_request
 
 permissions:

--- a/.github/workflows/stdarch.yml
+++ b/.github/workflows/stdarch.yml
@@ -1,7 +1,6 @@
 name: stdarch tests with sysroot compiled in release mode
 
 on:
-  - push
   - pull_request
 
 permissions:


### PR DESCRIPTION
There shouldn't be a need to run all CI jobs on all pushes.