### PR TITLE
fix backslashes in path used for `asm_tests`

### DIFF
--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -542,20 +542,21 @@ fn asm_tests(env: &Env, args: &TestArg) -> Result<(), String> {
 
     env.insert("COMPILETEST_FORCE_STAGE0".to_string(), "1".to_string());
 
-    let extra =
-        if args.is_using_gcc_master_branch() { "" } else { " -Csymbol-mangling-version=v0" };
-
-    let rustc_args = &format!(
-        r#"-Zpanic-abort-tests \
-            -Zcodegen-backend="{pwd}/target/{channel}/librustc_codegen_gcc.{dylib_ext}" \
-            --sysroot "{sysroot_dir}" -Cpanic=abort{extra}"#,
+    let codegen_backend_path = format!(
+        "{pwd}/target/{channel}/librustc_codegen_gcc.{dylib_ext}",
         pwd = std::env::current_dir()
             .map_err(|error| format!("`current_dir` failed: {:?}", error))?
             .display(),
         channel = args.config_info.channel.as_str(),
         dylib_ext = args.config_info.dylib_ext,
-        sysroot_dir = args.config_info.sysroot_path,
-        extra = extra,
+    );
+
+    let extra =
+        if args.is_using_gcc_master_branch() { "" } else { " -Csymbol-mangling-version=v0" };
+
+    let rustc_args = format!(
+        "-Zpanic-abort-tests -Zcodegen-backend={codegen_backend_path} --sysroot {} -Cpanic=abort{extra}",
+        args.config_info.sysroot_path
     );
 
     run_command_with_env(


### PR DESCRIPTION
fixes #622 

The problem is with escaping the `--compiletest-rustc-args` argument. Use of `\` and `"` or even `'` does not work because of how this string is eventually used.

With this change I can actually run the asm tests

```
failures:
    [assembly] tests/assembly/asm/global_asm.rs
    [assembly] tests/assembly/asm/inline-asm-avx.rs

test result: FAILED. 0 passed; 2 failed; 50 ignored; 0 measured; 465 filtered out; finished in 57.76ms

Some tests failed in compiletest suite=assembly mode=assembly host=x86_64-unknown-linux-gnu target=x86_64-unknown-linux-gnu
help: ignored 1 up-to-date test; use `--force-rerun` to prevent this
```

If it's useful I can re-enable this test in `run_all`, but only 2 tests actually run (the rest is ignored) and those both fail right now.