### PR TITLE
Added a .gitattributes file for showing cargo.lock diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-Cargo.lock text eol=lf linguist-generated=false
+Cargo.lock linguist-generated=false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Cargo.lock text eol=lf linguist-generated=false


### PR DESCRIPTION
This solves rust-lang/rustc_codegen_gcc#658

Also added a line to treat `Cargo.lock` as a text file and normalize eol.