### PR TITLE
Switch to 2024 edition and remove `let_chains` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustc_codegen_gcc"
 version = "0.1.0"
 authors = ["Antoni Boucher <bouanto@zoho.com>"]
-edition = "2018"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [lib]

--- a/build_system/Cargo.toml
+++ b/build_system/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "y"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 boml = "0.3.1"

--- a/build_system/src/main.rs
+++ b/build_system/src/main.rs
@@ -60,7 +60,9 @@ pub enum Command {
 
 fn main() {
     if env::var("RUST_BACKTRACE").is_err() {
-        env::set_var("RUST_BACKTRACE", "1");
+        unsafe {
+            env::set_var("RUST_BACKTRACE", "1");
+        }
     }
 
     let command = match env::args().nth(1).as_deref() {

--- a/build_system/src/utils.rs
+++ b/build_system/src/utils.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus, Output};
 
 #[cfg(unix)]
-extern "C" {
+unsafe extern "C" {
     fn raise(signal: c_int) -> c_int;
 }
 

--- a/src/back/lto.rs
+++ b/src/back/lto.rs
@@ -589,7 +589,7 @@ fn thin_lto(
     Ok((opt_jobs, copy_jobs))
 }
 
-pub unsafe fn optimize_thin_module(
+pub fn optimize_thin_module(
     thin_module: ThinModule<GccCodegenBackend>,
     _cgcx: &CodegenContext<GccCodegenBackend>,
 ) -> Result<ModuleCodegen<GccContext>, FatalError> {

--- a/src/back/write.rs
+++ b/src/back/write.rs
@@ -14,7 +14,7 @@ use crate::base::add_pic_option;
 use crate::errors::CopyBitcode;
 use crate::{GccCodegenBackend, GccContext};
 
-pub(crate) unsafe fn codegen(
+pub(crate) fn codegen(
     cgcx: &CodegenContext<GccCodegenBackend>,
     dcx: DiagCtxtHandle<'_>,
     module: ModuleCodegen<GccContext>,

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -191,13 +191,11 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
                 // TODO(antoyo): check if it's okay that no link_section is set.
 
                 let typ = self.val_ty(cv).get_aligned(align.bytes());
-                let global = self.declare_private_global(&name[..], typ);
-                global
+                self.declare_private_global(&name[..], typ)
             }
             _ => {
                 let typ = self.val_ty(cv).get_aligned(align.bytes());
-                let global = self.declare_unnamed_global(typ);
-                global
+                self.declare_unnamed_global(typ)
             }
         };
         global.global_set_initializer_rvalue(cv);

--- a/src/debuginfo.rs
+++ b/src/debuginfo.rs
@@ -289,7 +289,7 @@ impl<'gcc, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
     ) -> Self::DILocation {
         let pos = span.lo();
         let DebugLoc { file, line, col } = self.lookup_debug_loc(pos);
-        let loc = match file.name {
+        match file.name {
             rustc_span::FileName::Real(ref name) => match *name {
                 rustc_span::RealFileName::LocalPath(ref name) => {
                     if let Some(name) = name.to_str() {
@@ -314,7 +314,6 @@ impl<'gcc, 'tcx> DebugInfoCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
                 }
             },
             _ => Location::null(),
-        };
-        loc
+        }
     }
 }

--- a/src/declare.rs
+++ b/src/declare.rs
@@ -157,6 +157,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
 ///
 /// If there’s a value with the same name already declared, the function will
 /// update the declaration and return existing Value instead.
+#[allow(clippy::let_and_return)]
 fn declare_raw_fn<'gcc>(
     cx: &CodegenCx<'gcc, '_>,
     name: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         cgcx: &CodegenContext<Self>,
         thin: ThinModule<Self>,
     ) -> Result<ModuleCodegen<Self::Module>, FatalError> {
-        unsafe { back::lto::optimize_thin_module(thin, cgcx) }
+        back::lto::optimize_thin_module(thin, cgcx)
     }
 
     unsafe fn codegen(
@@ -422,7 +422,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
     ) -> Result<CompiledModule, FatalError> {
-        unsafe { back::write::codegen(cgcx, dcx, module, config) }
+        back::write::codegen(cgcx, dcx, module, config)
     }
 
     fn prepare_thin(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 #![allow(internal_features)]
 #![doc(rust_logo)]
 #![feature(rustdoc_internals)]
-#![feature(rustc_private, decl_macro, never_type, trusted_len, let_chains)]
+#![feature(rustc_private, decl_macro, never_type, trusted_len)]
 #![allow(broken_intra_doc_links)]
 #![recursion_limit = "256"]
 #![warn(rust_2018_idioms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         cgcx: &CodegenContext<Self>,
         thin: ThinModule<Self>,
     ) -> Result<ModuleCodegen<Self::Module>, FatalError> {
-        back::lto::optimize_thin_module(thin, cgcx)
+        unsafe { back::lto::optimize_thin_module(thin, cgcx) }
     }
 
     unsafe fn codegen(
@@ -422,7 +422,7 @@ impl WriteBackendMethods for GccCodegenBackend {
         module: ModuleCodegen<Self::Module>,
         config: &ModuleConfig,
     ) -> Result<CompiledModule, FatalError> {
-        back::write::codegen(cgcx, dcx, module, config)
+        unsafe { back::write::codegen(cgcx, dcx, module, config) }
     }
 
     fn prepare_thin(
@@ -454,7 +454,7 @@ impl WriteBackendMethods for GccCodegenBackend {
 }
 
 /// This is the entrypoint for a hot plugged rustc_codegen_gccjit
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub fn __rustc_codegen_backend() -> Box<dyn CodegenBackend> {
     #[cfg(feature = "master")]
     let info = {

--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -42,7 +42,9 @@ pub fn main_inner(profile: Profile) {
         .expect("failed to get absolute path of `gcc-path`")
         .display()
         .to_string();
-    env::set_var("LD_LIBRARY_PATH", gcc_path);
+    unsafe {
+        env::set_var("LD_LIBRARY_PATH", gcc_path);
+    }
 
     fn rust_filter(path: &Path) -> bool {
         path.is_file() && path.extension().expect("extension").to_str().expect("to_str") == "rs"

--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -69,15 +69,14 @@ pub fn main_inner(profile: Profile) {
         .test_dir("tests/run")
         .test_path_filter(filter)
         .test_extract(|path| {
-            let lines = std::fs::read_to_string(path)
+            std::fs::read_to_string(path)
                 .expect("read file")
                 .lines()
                 .skip_while(|l| !l.starts_with("//"))
                 .take_while(|l| l.starts_with("//"))
                 .map(|l| &l[2..])
                 .collect::<Vec<_>>()
-                .join("\n");
-            lines
+                .join("\n")
         })
         .test_cmds(move |path| {
             // Test command 1: Compile `x.rs` into `tempdir/x`.


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#662.