### PR TITLE
Add a workaround for 128 bit switches

### DIFF
--- a/example/mini_core.rs
+++ b/example/mini_core.rs
@@ -1,6 +1,14 @@
 #![feature(
-    no_core, lang_items, intrinsics, unboxed_closures, extern_types,
-    decl_macro, rustc_attrs, transparent_unions, auto_traits, freeze_impls,
+    no_core,
+    lang_items,
+    intrinsics,
+    unboxed_closures,
+    extern_types,
+    decl_macro,
+    rustc_attrs,
+    transparent_unions,
+    auto_traits,
+    freeze_impls,
     thread_local
 )]
 #![no_core]
@@ -35,13 +43,13 @@ impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<*mut U> for *mut T {}
 pub trait DispatchFromDyn<T> {}
 
 // &T -> &U
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a U> for &'a T {}
 // &mut T -> &mut U
-impl<'a, T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<&'a mut U> for &'a mut T {}
+impl<'a, T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<&'a mut U> for &'a mut T {}
 // *const T -> *const U
-impl<T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<*const U> for *const T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<*const U> for *const T {}
 // *mut T -> *mut U
-impl<T: ?Sized+Unsize<U>, U: ?Sized> DispatchFromDyn<*mut U> for *mut T {}
+impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<*mut U> for *mut T {}
 impl<T: ?Sized + Unsize<U>, U: ?Sized> DispatchFromDyn<Box<U, ()>> for Box<T, ()> {}
 
 #[lang = "legacy_receiver"]
@@ -52,8 +60,7 @@ impl<T: ?Sized> LegacyReceiver for &mut T {}
 impl<T: ?Sized, A: Allocator> LegacyReceiver for Box<T, A> {}
 
 #[lang = "receiver"]
-trait Receiver {
-}
+trait Receiver {}
 
 #[lang = "copy"]
 pub trait Copy {}
@@ -67,10 +74,13 @@ impl Copy for u16 {}
 impl Copy for u32 {}
 impl Copy for u64 {}
 impl Copy for usize {}
+impl Copy for u128 {}
 impl Copy for i8 {}
 impl Copy for i16 {}
 impl Copy for i32 {}
+impl Copy for i64 {}
 impl Copy for isize {}
+impl Copy for i128 {}
 impl Copy for f32 {}
 impl Copy for f64 {}
 impl Copy for char {}
@@ -336,7 +346,6 @@ impl PartialEq for u32 {
     }
 }
 
-
 impl PartialEq for u64 {
     fn eq(&self, other: &u64) -> bool {
         (*self) == (*other)
@@ -523,7 +532,11 @@ fn panic_in_cleanup() -> ! {
 #[track_caller]
 fn panic_bounds_check(index: usize, len: usize) -> ! {
     unsafe {
-        libc::printf("index out of bounds: the len is %d but the index is %d\n\0" as *const str as *const i8, len, index);
+        libc::printf(
+            "index out of bounds: the len is %d but the index is %d\n\0" as *const str as *const i8,
+            len,
+            index,
+        );
         intrinsics::abort();
     }
 }
@@ -551,8 +564,7 @@ pub trait Deref {
     fn deref(&self) -> &Self::Target;
 }
 
-pub trait Allocator {
-}
+pub trait Allocator {}
 
 impl Allocator for () {}
 
@@ -635,6 +647,8 @@ pub union MaybeUninit<T> {
 
 pub mod intrinsics {
     #[rustc_intrinsic]
+    pub const fn black_box<T>(_dummy: T) -> T;
+    #[rustc_intrinsic]
     pub fn abort() -> !;
     #[rustc_intrinsic]
     pub fn size_of<T>() -> usize;
@@ -711,19 +725,27 @@ pub struct VaList<'a>(&'a mut VaListImpl);
 
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
-pub macro stringify($($t:tt)*) { /* compiler built-in */ }
+pub macro stringify($($t:tt)*) {
+    /* compiler built-in */
+}
 
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
-pub macro file() { /* compiler built-in */ }
+pub macro file() {
+    /* compiler built-in */
+}
 
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
-pub macro line() { /* compiler built-in */ }
+pub macro line() {
+    /* compiler built-in */
+}
 
 #[rustc_builtin_macro]
 #[rustc_macro_transparency = "semitransparent"]
-pub macro cfg() { /* compiler built-in */ }
+pub macro cfg() {
+    /* compiler built-in */
+}
 
 pub static A_STATIC: u8 = 42;
 

--- a/tests/run/switchint_128bit.rs
+++ b/tests/run/switchint_128bit.rs
@@ -1,0 +1,37 @@
+// Compiler:
+//
+// Run-time:
+//   status: 0
+
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+#![no_main]
+
+extern crate mini_core;
+use intrinsics::black_box;
+use mini_core::*;
+
+#[no_mangle]
+extern "C" fn main(argc: i32, _argv: *const *const u8) -> i32 {
+    // 1st. Check that small 128 bit values work.
+    let val = black_box(64_u128);
+    match val {
+        0 => return 1,
+        1 => return 2,
+        64 => (),
+        _ => return 3,
+    }
+    // 2nd check that *large* values work.
+    const BIG: u128 = 0xDEAD_C0FE_BEEF_DECAF_BADD_DECAF_BEEF_u128;
+    let val = black_box(BIG);
+    match val {
+        0 => return 4,
+        1 => return 5,
+        // Check that we will not match on the lower u64, if the upper qword is different!
+        0xcafbadddecafbeef => return 6,
+        0xDEAD_C0FE_BEEF_DECAF_BADD_DECAF_BEEF_u128 => (),
+        _ => return 7,
+    }
+    0
+}


### PR DESCRIPTION
Due to a libgccjit limitation, 128 bit switches are currently not supported.

As a workaround, this PR:
1. Detects switches on 16 byte(128 bit) values.
2. Replaces such switches with an "if ladder".

Effectively, we turn this:
```rust
let val = black_box(64_u128);
match val {
    0 => return 1,
    1 => return 2,
    64 => (),
    _ => return 3,
}
```
Into this:
```rust
let val = black_box(64_u128);
if val == 0{
  return 1;
}
else if val == 1{
   return 2;
}
else if val ==   64 {
} else {
   return 3; 
}
```
This is less efficient than a switch, but it **only** applies to previously unsupported edge case: 128 bit switches. So, the small perf penalty is acceptable in this case.

Besides that, this PR contains a regression test for this issue, and a few tiny changes to minicore. 

1. Added support for the `black_box` intrinsic - it is strictly necessary for correct tests. **Even now**, MIR optimizations sometimes optimize the crash I test for away.  Using `black_box` guarantees we will not miss any issues in the future. 

2. Added copy impls for `i64`, `u128`, and `i128`. The `u128` impl was needed to properly test 128 bit switches. Adding one for `i128` too seemed reasonable. 