### PR TITLE
modifed y.sh to allow for running cargo tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,6 @@ jobs:
     - name: Set env
       run: |
         echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
-        echo "LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
 
     #- name: Cache rust repository
       ## We only clone the rust repository for rustc tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,7 @@ jobs:
       run: |
         ./y.sh prepare --only-libcore
         ./y.sh build --sysroot
-        ./y.sh test --mini-tests
-        cargo test
+        ./y.sh test --cargo-tests
 
     - name: Run y.sh cargo build
       run: |

--- a/.github/workflows/failures.yml
+++ b/.github/workflows/failures.yml
@@ -66,8 +66,8 @@ jobs:
       run: |
           sudo dpkg --force-overwrite -i gcc-15.deb
           echo 'gcc-path = "/usr/lib"' > config.toml
-          echo "LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
+          
+          
 
     - name: Set env
       run: |

--- a/.github/workflows/m68k.yml
+++ b/.github/workflows/m68k.yml
@@ -95,7 +95,7 @@ jobs:
         ./y.sh prepare --only-libcore --cross
         ./y.sh build --sysroot --features compiler_builtins/no-f16-f128 --target-triple m68k-unknown-linux-gnu
         ./y.sh test --mini-tests
-        CG_GCC_TEST_TARGET=m68k-unknown-linux-gnu cargo test
+        CG_GCC_TEST_TARGET=m68k-unknown-linux-gnu ./y.sh test --cargo-tests
         ./y.sh clean all
 
     - name: Prepare dependencies

--- a/.github/workflows/m68k.yml
+++ b/.github/workflows/m68k.yml
@@ -65,8 +65,8 @@ jobs:
     - name: Set env
       run: |
         echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
-        echo "LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
+        
+        
 
     #- name: Cache rust repository
       ## We only clone the rust repository for rustc tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,7 @@ jobs:
       run: |
         ./y.sh prepare --only-libcore
         EMBED_LTO_BITCODE=1 ./y.sh build --sysroot --release --release-sysroot
-        ./y.sh test --mini-tests
-        cargo test
+        ./y.sh test --cargo-tests
         ./y.sh clean all
 
     - name: Prepare dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Set env
       run: |
         echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
-        echo "LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/usr/lib" >> $GITHUB_ENV
+        
+        
 
     - name: Build
       run: |

--- a/.github/workflows/stdarch.yml
+++ b/.github/workflows/stdarch.yml
@@ -90,7 +90,7 @@ jobs:
       if: ${{ !matrix.cargo_runner }}
       run: |
         ./y.sh test --release --clean --release-sysroot --build-sysroot --mini-tests --std-tests --test-libcore
-        cargo test
+        ./y.sh test --cargo-tests
 
     - name: Run stdarch tests
       if: ${{ !matrix.cargo_runner }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ To run specific tests, use appropriate flags such as:
 
 - `./y.sh test --test-libcore`
 - `./y.sh test --std-tests`
-- `cargo test -- <name of test>`
+- `./y.sh test --cargo-tests -- <name of test>`
 
 Additionally, you can run the tests of `libgccjit`:
 

--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -42,7 +42,7 @@ fn get_runners() -> Runners {
     );
     runners.insert("--extended-regex-tests", ("Run extended regex tests", extended_regex_tests));
     runners.insert("--mini-tests", ("Run mini tests", mini_tests));
-
+    runners.insert("--cargo-tests", ("Run cargo tests", cargo_tests));
     runners
 }
 
@@ -88,6 +88,8 @@ struct TestArg {
     use_system_gcc: bool,
     runners: Vec<String>,
     flags: Vec<String>,
+    /// Additional arguments, to be passed to commands like `cargo test`.
+    test_args: Vec<String>,
     nb_parts: Option<usize>,
     current_part: Option<usize>,
     sysroot_panic_abort: bool,
@@ -144,6 +146,7 @@ impl TestArg {
                     show_usage();
                     return Ok(None);
                 }
+                "--" => test_arg.test_args.extend(&mut args),
                 x if runners.contains_key(x)
                     && !test_arg.runners.iter().any(|runner| runner == x) =>
                 {
@@ -201,6 +204,33 @@ fn clean(_env: &Env, args: &TestArg) -> Result<(), String> {
     let _ = remove_dir_all(&args.config_info.cargo_target_dir);
     let path = Path::new(&args.config_info.cargo_target_dir).join("gccjit");
     create_dir(&path)
+}
+
+fn cargo_tests(test_env: &Env, test_args: &TestArg) -> Result<(), String> {
+    // First, we call `mini_tests` to build minicore for us. This ensures we are testing with a working `minicore`,
+    // and that any changes we have made affect `minicore`(since it would get rebuilt).
+    mini_tests(test_env, test_args)?;
+    // Then, we copy some of the env vars from `test_env`
+    // We don't want to pass things like `RUSTFLAGS`, since they contain the -Zcodegen-backend flag.
+    // That would force `cg_gcc` to *rebuild itself* and only then run tests, which is undesirable.
+    let mut env = HashMap::new();
+    env.insert(
+        "LD_LIBRARY_PATH".into(),
+        test_env.get("LD_LIBRARY_PATH").expect("LD_LIBRARY_PATH missing!").to_string(),
+    );
+    env.insert(
+        "LIBRARY_PATH".into(),
+        test_env.get("LIBRARY_PATH").expect("LIBRARY_PATH missing!").to_string(),
+    );
+    env.insert(
+        "CG_RUSTFLAGS".into(),
+        test_env.get("CG_RUSTFLAGS").map(|s| s.as_str()).unwrap_or("").to_string(),
+    );
+    // Pass all the default args + the user-specified ones.
+    let mut args: Vec<&dyn AsRef<OsStr>> = vec![&"cargo", &"test"];
+    args.extend(test_args.test_args.iter().map(|s| s as &dyn AsRef<OsStr>));
+    run_command_with_output_and_env(&args, None, Some(&env))?;
+    Ok(())
 }
 
 fn mini_tests(env: &Env, args: &TestArg) -> Result<(), String> {
@@ -1217,7 +1247,9 @@ fn run_all(env: &Env, args: &TestArg) -> Result<(), String> {
     // asm_tests(env, args)?;
     test_libcore(env, args)?;
     extended_sysroot_tests(env, args)?;
+    cargo_tests(env, args)?;
     test_rustc(env, args)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
Added a new option to `./y.sh test`: ` ./y.sh test --cargo-tests`.

When this option is selected, `y.sh` will build & test minicore(it is a dependency). After that, it will simply call `cargo test` with the selected environment flags.  

For now  ` ./y.sh test --cargo-tests`  ignores `RUSTFLAGS`. 

Normally, `RUSTFLAGS` contain the `-Zcodegen-backend` option, which would make `cg_gcc` rebuild itself. This is undesirable, and ignoring `RUSTFLAGS` altogether was simply the easiest option. 

In the future, we maybe could filter out `-Zcodegen-backend`, and keep the rest of the flags intact. 