### PR TITLE
Fix UB in 128 bit cttz/ctlz intrinsics

### DIFF
--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -115,7 +115,9 @@ pub fn main_inner(profile: Profile) {
                 }
             }
             match profile {
-                Profile::Debug => {}
+                Profile::Debug => {
+                    compiler.args(["-C", "llvm-args=santize-undefined"]);
+                }
                 Profile::Release => {
                     compiler.args(["-C", "opt-level=3", "-C", "lto=no"]);
                 }

--- a/tests/run/bitintrinsics_128.rs
+++ b/tests/run/bitintrinsics_128.rs
@@ -1,0 +1,38 @@
+// Compiler:
+//
+// Run-time:
+
+#![feature(no_core, intrinsics)]
+#![no_std]
+#![no_core]
+#![no_main]
+
+extern crate mini_core;
+use intrinsics::black_box;
+use mini_core::*;
+
+#[rustc_intrinsic]
+pub const fn ctlz<T: Copy>(_x: T) -> u32;
+
+#[rustc_intrinsic]
+pub const fn cttz<T: Copy>(_x: T) -> u32;
+
+#[no_mangle]
+extern "C" fn main(argc: i32, _argv: *const *const u8) -> i32 {
+    if ctlz(black_box(0_u128)) != 128 {
+        return 1;
+    }
+    if ctlz(black_box(1_u128)) != 127 {
+        return 2;
+    }
+    if cttz(black_box(0_u128)) != 128 {
+        return 3;
+    }
+    if cttz(black_box(1_u128)) != 0 {
+        return 4;
+    }
+    if cttz(black_box(2_u128)) != 1 {
+        return 4;
+    }
+    0
+}


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustc_codegen_gcc/issues/604.

This PR changes a few things. 

First of all, it enables UB checks for tests in debug mode: This should allow us to catch any regressions.

Second, I extracted the common implementation of the "safe" `ctlz`/`cttz` intrinsics into a separate function. 

This makes handling the 128 bit edge case a bit easier, and allows us to use those intrinsics.

The third change modifies the 128 bit  `ctlz`/`cttz` emulation to use the "safe" version of the 64 bit intrinsic, instead of calling the GCC built-in directly.

Effectively, this turns a piece of IR like this:

```rust
// Get the ctlz for the low and high half of the 128 bit integer
let ctlz_low = ctlz_nonzero(low);
let ctlz_high = ctlz_nonzero(high);
```

Into a piece of code like this:

```rust
// Get the ctlz for the low and high half of the 128 bit integer
let ctlz_low = if low != 0 {ctlz_nonzero(low)} else {64};
let ctlz_high = if high != 0 {ctlz_nonzero(high)} else {64};
```

This solution is not the prettiest(maybe a few less branches could be used?), but it is UB-free, and relatively easy to implement.  

