### PR TITLE
Add missing `add_eval` to generate `__rdl_oom` in the alloc error handler

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -152,6 +152,7 @@ fn create_wrapper_function(
     if output.is_some() {
         block.end_with_return(None, ret);
     } else {
+        block.add_eval(None, ret);
         block.end_with_void_return(None);
     }
 


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#674.

With this change we now have:

```asm
000000000000505f <_RNvCsee83jQymicr_7___rustc26___rust_alloc_error_handler>:
    505f:       55                      push   %rbp
    5060:       48 89 e5                mov    %rsp,%rbp
    5063:       48 83 ec 10             sub    $0x10,%rsp
    5067:       48 89 7d f8             mov    %rdi,-0x8(%rbp)
    506b:       48 89 75 f0             mov    %rsi,-0x10(%rbp)
    506f:       48 8b 55 f0             mov    -0x10(%rbp),%rdx
    5073:       48 8b 45 f8             mov    -0x8(%rbp),%rax
    5077:       48 89 d6                mov    %rdx,%rsi
    507a:       48 89 c7                mov    %rax,%rdi
    507d:       e8 58 09 00 00          call   59da <_RNvCsee83jQymicr_7___rustc9___rdl_oom>
    5082:       c9                      leave
    5083:       c3                      ret
```