### PR TITLE
Fix to 128 bit int unaligned loads

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -924,7 +924,12 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         // dereference after a drop, for instance.
         // FIXME(antoyo): this check that we don't call get_aligned() a second time on a type.
         // Ideally, we shouldn't need to do this check.
-        let aligned_type = if pointee_ty == self.cx.u128_type || pointee_ty == self.cx.i128_type {
+        // FractalFir: the `align == self.int128_align` check ensures we *do* call `get_aligned` if
+        // the alignment of a `u128`/`i128` is not the one mandated by the ABI. This ensures we handle
+        // under-aligned loads correctly.
+        let aligned_type = if (pointee_ty == self.cx.u128_type || pointee_ty == self.cx.i128_type)
+            && align == self.int128_align
+        {
             pointee_ty
         } else {
             pointee_ty.get_aligned(align.bytes())

--- a/tests/run/packed_u128.rs
+++ b/tests/run/packed_u128.rs
@@ -1,0 +1,31 @@
+// Compiler:
+//
+// Run-time:
+//   status: 0
+
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+#![no_main]
+
+extern crate mini_core;
+use intrinsics::black_box;
+use mini_core::*;
+#[repr(packed(1))]
+pub struct ScalarInt {
+    data: u128,
+    size: u8,
+}
+#[inline(never)]
+#[no_mangle]
+fn read_data(a: &ScalarInt) {
+    black_box(a.data);
+}
+
+#[no_mangle]
+extern "C" fn main(argc: i32, _argv: *const *const u8) -> i32 {
+    let data =
+        [black_box(ScalarInt { data: 0, size: 1 }), black_box(ScalarInt { data: 0, size: 1 })];
+    read_data(&data[1]);
+    0
+}


### PR DESCRIPTION
This PR fixes the segfault caused by packed structs containing u128 / i128.  https://github.com/rust-lang/rustc_codegen_gcc/issues/683

I also added a test to detect any regressions like this in the future. 