### PR TITLE
Added some bare-bones support for explict registers in ARM inline assembly

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -641,7 +641,8 @@ fn explicit_reg_to_gcc(reg: InlineAsmReg) -> &'static str {
                 },
             }
         }
-
+        InlineAsmReg::Arm(reg) => reg.name(),
+        InlineAsmReg::AArch64(reg) => reg.name(),
         _ => unimplemented!(),
     }
 }


### PR DESCRIPTION
A tiny patch adding the very basic support for explicit registers in ARM/AArch64 assembly.