### PR TITLE
Use `tempfile::TempDir::keep()` instead of deprecated `into_path()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ impl CodegenBackend for GccCodegenBackend {
         #[cfg(not(feature = "master"))]
         {
             let temp_dir = TempDir::new().expect("cannot create temporary directory");
-            let temp_file = temp_dir.into_path().join("result.asm");
+            let temp_file = temp_dir.keep().join("result.asm");
             let check_context = Context::default();
             check_context.set_print_errors_to_stderr(false);
             let _int128_ty = check_context.new_c_type(CType::UInt128t);


### PR DESCRIPTION
## PR Summary
The tempfile library has deprecated `TempDir::into_path()`, replacing it by `TempDir::keep()` starting version 3.3. It leads to the following warnings which you can find in the [CI logs](https://github.com/rust-lang/rustc_codegen_gcc/actions/runs/15564268760/job/43824248563#step:8:54):
```rust
warning: use of deprecated method `tempfile::TempDir::into_path`: use TempDir::keep()
   --> src/lib.rs:211:38
    |
211 |             let temp_file = temp_dir.into_path().join("result.asm");
```