### PR TITLE
Added support for testing the backend with abi-cafe

### DIFF
--- a/build_system/src/abi_test.rs
+++ b/build_system/src/abi_test.rs
@@ -1,0 +1,62 @@
+use std::ffi::OsStr;
+use std::path::Path;
+
+use crate::utils::run_command_with_output;
+
+fn show_usage() {
+    println!(
+        r#"
+`abi-test` command help:
+    --help                 : Show this help"#
+    );
+}
+
+pub fn run() -> Result<(), String> {
+    let mut args = std::env::args().skip(2);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--help" => {
+                show_usage();
+                return Ok(());
+            }
+            _ => return Err(format!("Unknown option {}", arg)),
+        }
+    }
+    // Ensure that we have a cloned version of abi-cafe on hand.
+    crate::utils::git_clone(
+        "https://github.com/Gankra/abi-cafe.git",
+        Some("clones/abi-cafe".as_ref()),
+        true,
+    )
+    .map_err(|err| (format!("Git clone failed with message: {err:?}!")))?;
+    // Configure abi-cafe to use the exact same rustc version we use - this is crucial.
+    // Otherwise, the concept of ABI compatibility becomes meanignless.
+    std::fs::copy("rust-toolchain", "clones/abi-cafe/rust-toolchain")
+        .expect("Could not copy toolchain configs!");
+    // Get the backend path.
+    // We will use the *debug* build of the backend - it has more checks enabled.
+    let backend_path = std::path::absolute("target/debug/librustc_codegen_gcc.so").unwrap();
+    let backend_arg = format!("--add-rustc-codegen-backend=cg_gcc:{}", backend_path.display());
+    // Run ABI cafe using cargo.
+    let cmd: &[&dyn AsRef<OsStr>] = &[
+        &"cargo",
+        &"run",
+        &"--release",
+        &"--",
+        &backend_arg,
+        // Test rust-LLVM to Rust-GCC calls
+        &"--pairs",
+        &"rustc_calls_cg_gcc",
+        &"--pairs",
+        &"cg_gcc_calls_rustc",
+        // Test Rust-GCC to C calls
+        &"--pairs",
+        &"cg_gcc_calls_c",
+        &"--pairs",
+        &"c_calls_cg_gcc",
+    ];
+    // Run ABI cafe.
+    run_command_with_output(cmd, Some(&Path::new("clones/abi-cafe")))?;
+
+    Ok(())
+}

--- a/build_system/src/main.rs
+++ b/build_system/src/main.rs
@@ -1,5 +1,6 @@
 use std::{env, process};
 
+mod abi_test;
 mod build;
 mod clean;
 mod clone_gcc;
@@ -12,7 +13,6 @@ mod rust_tools;
 mod rustc_info;
 mod test;
 mod utils;
-
 const BUILD_DIR: &str = "build";
 
 macro_rules! arg_error {
@@ -44,7 +44,8 @@ Commands:
         info      : Displays information about the build environment and project configuration.
         clone-gcc : Clones the GCC compiler from a specified source.
         fmt       : Runs rustfmt
-        fuzz      : Fuzzes `cg_gcc` using rustlantis"
+        fuzz      : Fuzzes `cg_gcc` using rustlantis
+        abi-test   : Runs the abi-cafe test suite on the codegen, checking for ABI compatibility with LLVM"
     );
 }
 
@@ -59,6 +60,7 @@ pub enum Command {
     Info,
     Fmt,
     Fuzz,
+    AbiTest,
 }
 
 fn main() {
@@ -77,6 +79,7 @@ fn main() {
         Some("test") => Command::Test,
         Some("info") => Command::Info,
         Some("clone-gcc") => Command::CloneGcc,
+        Some("abi-test") => Command::AbiTest,
         Some("fmt") => Command::Fmt,
         Some("fuzz") => Command::Fuzz,
         Some("--help") => {
@@ -102,6 +105,7 @@ fn main() {
         Command::CloneGcc => clone_gcc::run(),
         Command::Fmt => fmt::run(),
         Command::Fuzz => fuzz::run(),
+        Command::AbiTest => abi_test::run(),
     } {
         eprintln!("Command failed to run: {e}");
         process::exit(1);


### PR DESCRIPTION
I added a new command(abi-test) that runs the abi-cafe test suite, comparing the ABI implemented by the LLVM version of Rustc, and the GCC version of rustc.

Additionally, as a base sanity check, the command will also compare the implementation of the C abi in cg_gcc and in the system's C compiler.