### PR TITLE
Fix fuzz warnings and deny warnings by default in build system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,20 @@ jobs:
         #path: rust
         #key: ${{ runner.os }}-packages-${{ hashFiles('rust/.git/HEAD') }}
 
+    - name: Prepare
+      run: ./y.sh prepare --only-libcore
+
+    - name: Check formatting
+      run: ./y.sh fmt --check
+
+    - name: clippy
+      run: |
+        cargo clippy --all-targets -- -D warnings
+        cargo clippy --all-targets --no-default-features -- -D warnings
+        cargo clippy --manifest-path build_system/Cargo.toml --all-targets -- -D warnings
+
     - name: Build
       run: |
-        ./y.sh prepare --only-libcore
         ./y.sh build --sysroot
         ./y.sh test --cargo-tests
 
@@ -105,14 +116,6 @@ jobs:
     - name: Run tests
       run: |
         ./y.sh test --release --clean --build-sysroot ${{ matrix.commands }}
-
-    - name: Check formatting
-      run: ./y.sh fmt --check
-
-    - name: clippy
-      run: |
-        cargo clippy --all-targets -- -D warnings
-        cargo clippy --all-targets --features master -- -D warnings
 
   duplicates:
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -111,9 +123,9 @@ checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "memchr"
@@ -136,6 +148,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "regex"
@@ -166,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -188,12 +206,12 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -240,6 +258,15 @@ checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
 ]
 
 [[package]]
@@ -345,3 +372,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ gccjit = "2.7"
 [dev-dependencies]
 boml = "0.3.1"
 lang_tester = "0.8.0"
-tempfile = "3.7.1"
+tempfile = "3.20"
 
 [profile.dev]
 # By compiling dependencies with optimizations, performing tests gets much faster.

--- a/build_system/src/build.rs
+++ b/build_system/src/build.rs
@@ -33,7 +33,7 @@ impl BuildArg {
                 }
                 arg => {
                     if !build_arg.config_info.parse_argument(arg, &mut args)? {
-                        return Err(format!("Unknown argument `{}`", arg));
+                        return Err(format!("Unknown argument `{arg}`"));
                     }
                 }
             }
@@ -105,14 +105,14 @@ pub fn create_build_sysroot_content(start_dir: &Path) -> Result<(), String> {
     if !start_dir.is_dir() {
         create_dir(start_dir)?;
     }
-    copy_file("build_system/build_sysroot/Cargo.toml", &start_dir.join("Cargo.toml"))?;
-    copy_file("build_system/build_sysroot/Cargo.lock", &start_dir.join("Cargo.lock"))?;
+    copy_file("build_system/build_sysroot/Cargo.toml", start_dir.join("Cargo.toml"))?;
+    copy_file("build_system/build_sysroot/Cargo.lock", start_dir.join("Cargo.lock"))?;
 
     let src_dir = start_dir.join("src");
     if !src_dir.is_dir() {
         create_dir(&src_dir)?;
     }
-    copy_file("build_system/build_sysroot/lib.rs", &start_dir.join("src/lib.rs"))
+    copy_file("build_system/build_sysroot/lib.rs", start_dir.join("src/lib.rs"))
 }
 
 pub fn build_sysroot(env: &HashMap<String, String>, config: &ConfigInfo) -> Result<(), String> {
@@ -169,7 +169,7 @@ pub fn build_sysroot(env: &HashMap<String, String>, config: &ConfigInfo) -> Resu
         run_command(&[&"cp", &"-r", &dir_to_copy, &sysroot_path], None).map(|_| ())
     };
     walk_dir(
-        start_dir.join(&format!("target/{}/{}/deps", config.target_triple, channel)),
+        start_dir.join(format!("target/{}/{}/deps", config.target_triple, channel)),
         &mut copier.clone(),
         &mut copier,
         false,

--- a/build_system/src/clean.rs
+++ b/build_system/src/clean.rs
@@ -17,12 +17,12 @@ enum CleanArg {
 impl CleanArg {
     fn new() -> Result<Self, String> {
         // We skip the binary and the "clean" option.
-        for arg in std::env::args().skip(2) {
+        if let Some(arg) = std::env::args().nth(2) {
             return match arg.as_str() {
                 "all" => Ok(Self::All),
                 "ui-tests" => Ok(Self::UiTests),
                 "--help" => Ok(Self::Help),
-                a => Err(format!("Unknown argument `{}`", a)),
+                a => Err(format!("Unknown argument `{a}`")),
             };
         }
         Ok(Self::default())

--- a/build_system/src/clone_gcc.rs
+++ b/build_system/src/clone_gcc.rs
@@ -43,7 +43,7 @@ impl Args {
                 }
                 arg => {
                     if !command_args.config_info.parse_argument(arg, &mut args)? {
-                        return Err(format!("Unknown option {}", arg));
+                        return Err(format!("Unknown option {arg}"));
                     }
                 }
             }
@@ -52,7 +52,7 @@ impl Args {
             Some(p) => p.into(),
             None => PathBuf::from("./gcc"),
         };
-        return Ok(Some(command_args));
+        Ok(Some(command_args))
     }
 }
 
@@ -64,7 +64,7 @@ pub fn run() -> Result<(), String> {
     let result = git_clone("https://github.com/rust-lang/gcc", Some(&args.out_path), false)?;
     if result.ran_clone {
         let gcc_commit = args.config_info.get_gcc_commit()?;
-        println!("Checking out GCC commit `{}`...", gcc_commit);
+        println!("Checking out GCC commit `{gcc_commit}`...");
         run_command_with_output(
             &[&"git", &"checkout", &gcc_commit],
             Some(Path::new(&result.repo_dir)),

--- a/build_system/src/fmt.rs
+++ b/build_system/src/fmt.rs
@@ -16,21 +16,21 @@ fn show_usage() {
 pub fn run() -> Result<(), String> {
     let mut check = false;
     // We skip binary name and the `info` command.
-    let mut args = std::env::args().skip(2);
-    while let Some(arg) = args.next() {
+    let args = std::env::args().skip(2);
+    for arg in args {
         match arg.as_str() {
             "--help" => {
                 show_usage();
                 return Ok(());
             }
             "--check" => check = true,
-            _ => return Err(format!("Unknown option {}", arg)),
+            _ => return Err(format!("Unknown option {arg}")),
         }
     }
 
     let cmd: &[&dyn AsRef<OsStr>] =
         if check { &[&"cargo", &"fmt", &"--check"] } else { &[&"cargo", &"fmt"] };
 
-    run_command_with_output(cmd, Some(&Path::new(".")))?;
-    run_command_with_output(cmd, Some(&Path::new("build_system")))
+    run_command_with_output(cmd, Some(Path::new(".")))?;
+    run_command_with_output(cmd, Some(Path::new("build_system")))
 }

--- a/build_system/src/fuzz/reduce.rs
+++ b/build_system/src/fuzz/reduce.rs
@@ -39,7 +39,6 @@ fn remove_dup_assign(
     ends: usize,
     cache: &mut ResultCache,
 ) {
-    let mut curr = 0;
     let mut file_copy = file.clone();
     let mut reduction_count = 0;
     // Not worth it.
@@ -427,7 +426,6 @@ pub(super) fn reduce(path: impl AsRef<Path>) {
     println!("running `linearize_cf` on {path:?}.");
     linearize_cf(&mut file, &path, &mut cache);
     let mut out = std::fs::File::create(&path).expect("Could not save the reduction result.");
-    for line in file {
-        out.write_all(line.as_bytes());
-    }
+    let file = file.into_iter().collect::<String>();
+    out.write_all(file.as_bytes()).expect("failed to write into file");
 }

--- a/build_system/src/info.rs
+++ b/build_system/src/info.rs
@@ -15,7 +15,7 @@ pub fn run() -> Result<(), String> {
     config.no_download = true;
     config.setup_gcc_path()?;
     if let Some(gcc_path) = config.gcc_path {
-        println!("{}", gcc_path);
+        println!("{gcc_path}");
     }
     Ok(())
 }

--- a/build_system/src/prepare.rs
+++ b/build_system/src/prepare.rs
@@ -18,9 +18,9 @@ fn prepare_libcore(
     if let Some(path) = sysroot_source {
         rustlib_dir = Path::new(&path)
             .canonicalize()
-            .map_err(|error| format!("Failed to canonicalize path: {:?}", error))?;
+            .map_err(|error| format!("Failed to canonicalize path: {error:?}"))?;
         if !rustlib_dir.is_dir() {
-            return Err(format!("Custom sysroot path {:?} not found", rustlib_dir));
+            return Err(format!("Custom sysroot path {rustlib_dir:?} not found"));
         }
     } else {
         let rustc_path = match get_rustc_path() {
@@ -36,17 +36,17 @@ fn prepare_libcore(
         rustlib_dir = parent
             .join("../lib/rustlib/src/rust")
             .canonicalize()
-            .map_err(|error| format!("Failed to canonicalize path: {:?}", error))?;
+            .map_err(|error| format!("Failed to canonicalize path: {error:?}"))?;
         if !rustlib_dir.is_dir() {
             return Err("Please install `rust-src` component".to_string());
         }
     }
 
     let sysroot_dir = sysroot_path.join("sysroot_src");
-    if sysroot_dir.is_dir() {
-        if let Err(error) = fs::remove_dir_all(&sysroot_dir) {
-            return Err(format!("Failed to remove `{}`: {:?}", sysroot_dir.display(), error,));
-        }
+    if sysroot_dir.is_dir()
+        && let Err(error) = fs::remove_dir_all(&sysroot_dir)
+    {
+        return Err(format!("Failed to remove `{}`: {:?}", sysroot_dir.display(), error,));
     }
 
     let sysroot_library_dir = sysroot_dir.join("library");
@@ -122,7 +122,7 @@ fn prepare_rand() -> Result<(), String> {
     // Apply patch for the rand crate.
     let file_path = "patches/crates/0001-Remove-deny-warnings.patch";
     let rand_dir = Path::new("build/rand");
-    println!("[GIT] apply `{}`", file_path);
+    println!("[GIT] apply `{file_path}`");
     let path = Path::new("../..").join(file_path);
     run_command_with_output(&[&"git", &"apply", &path], Some(rand_dir))?;
     run_command_with_output(&[&"git", &"add", &"-A"], Some(rand_dir))?;
@@ -149,7 +149,7 @@ fn clone_and_setup<F>(repo_url: &str, checkout_commit: &str, extra: Option<F>) -
 where
     F: Fn(&Path) -> Result<(), String>,
 {
-    let clone_result = git_clone_root_dir(repo_url, &Path::new(crate::BUILD_DIR), false)?;
+    let clone_result = git_clone_root_dir(repo_url, Path::new(crate::BUILD_DIR), false)?;
     if !clone_result.ran_clone {
         println!("`{}` has already been cloned", clone_result.repo_name);
     }

--- a/build_system/src/rust_tools.rs
+++ b/build_system/src/rust_tools.rs
@@ -9,15 +9,14 @@ use crate::utils::{get_toolchain, rustc_toolchain_version_info, rustc_version_in
 
 fn args(command: &str) -> Result<Option<Vec<String>>, String> {
     // We skip the binary and the "cargo"/"rustc" option.
-    if let Some("--help") = std::env::args().skip(2).next().as_deref() {
+    if let Some("--help") = std::env::args().nth(2).as_deref() {
         usage(command);
         return Ok(None);
     }
     let args = std::env::args().skip(2).collect::<Vec<_>>();
     if args.is_empty() {
         return Err(format!(
-            "Expected at least one argument for `{}` subcommand, found none",
-            command
+            "Expected at least one argument for `{command}` subcommand, found none"
         ));
     }
     Ok(Some(args))
@@ -26,12 +25,11 @@ fn args(command: &str) -> Result<Option<Vec<String>>, String> {
 fn usage(command: &str) {
     println!(
         r#"
-`{}` command help:
+`{command}` command help:
 
     [args]     : Arguments to be passed to the cargo command
     --help     : Show this help
 "#,
-        command,
     )
 }
 
@@ -50,10 +48,10 @@ impl RustcTools {
         // expected.
         let current_dir = std::env::current_dir()
             .and_then(|path| path.canonicalize())
-            .map_err(|error| format!("Failed to get current directory path: {:?}", error))?;
+            .map_err(|error| format!("Failed to get current directory path: {error:?}"))?;
         let current_exe = std::env::current_exe()
             .and_then(|path| path.canonicalize())
-            .map_err(|error| format!("Failed to get current exe path: {:?}", error))?;
+            .map_err(|error| format!("Failed to get current exe path: {error:?}"))?;
         let mut parent_dir =
             current_exe.components().map(|comp| comp.as_os_str()).collect::<Vec<_>>();
         // We run this script from "build_system/target/release/y", so we need to remove these elements.
@@ -67,7 +65,7 @@ impl RustcTools {
                 ));
             }
         }
-        let parent_dir = PathBuf::from(parent_dir.join(&OsStr::new("/")));
+        let parent_dir = PathBuf::from(parent_dir.join(OsStr::new("/")));
         std::env::set_current_dir(&parent_dir).map_err(|error| {
             format!("Failed to go to `{}` folder: {:?}", parent_dir.display(), error)
         })?;
@@ -91,7 +89,7 @@ impl RustcTools {
         std::env::set_current_dir(&current_dir).map_err(|error| {
             format!("Failed to go back to `{}` folder: {:?}", current_dir.display(), error)
         })?;
-        let toolchain = format!("+{}", toolchain);
+        let toolchain = format!("+{toolchain}");
         Ok(Some(Self { toolchain, args, env, config }))
     }
 }

--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -53,9 +53,9 @@ fn get_number_after_arg(
     match args.next() {
         Some(nb) if !nb.is_empty() => match usize::from_str(&nb) {
             Ok(nb) => Ok(nb),
-            Err(_) => Err(format!("Expected a number after `{}`, found `{}`", option, nb)),
+            Err(_) => Err(format!("Expected a number after `{option}`, found `{nb}`")),
         },
-        _ => Err(format!("Expected a number after `{}`, found nothing", option)),
+        _ => Err(format!("Expected a number after `{option}`, found nothing")),
     }
 }
 
@@ -76,8 +76,8 @@ fn show_usage() {
     for (option, (doc, _)) in get_runners() {
         // FIXME: Instead of using the hard-coded `23` value, better to compute it instead.
         let needed_spaces = 23_usize.saturating_sub(option.len());
-        let spaces: String = std::iter::repeat(' ').take(needed_spaces).collect();
-        println!("    {}{}: {}", option, spaces, doc);
+        let spaces: String = std::iter::repeat_n(' ', needed_spaces).collect();
+        println!("    {option}{spaces}: {doc}");
     }
     println!("    --help                 : Show this help");
 }
@@ -139,7 +139,7 @@ impl TestArg {
                         test_arg.sysroot_features.push(feature);
                     }
                     _ => {
-                        return Err(format!("Expected an argument after `{}`, found nothing", arg));
+                        return Err(format!("Expected an argument after `{arg}`, found nothing"));
                     }
                 },
                 "--help" => {
@@ -154,7 +154,7 @@ impl TestArg {
                 }
                 arg => {
                     if !test_arg.config_info.parse_argument(arg, &mut args)? {
-                        return Err(format!("Unknown option {}", arg));
+                        return Err(format!("Unknown option {arg}"));
                     }
                 }
             }
@@ -192,7 +192,7 @@ fn build_if_no_backend(env: &Env, args: &TestArg) -> Result<(), String> {
         command.push(&"--release");
         &tmp_env
     } else {
-        &env
+        env
     };
     for flag in args.flags.iter() {
         command.push(flag);
@@ -252,7 +252,7 @@ fn mini_tests(env: &Env, args: &TestArg) -> Result<(), String> {
         &"--target",
         &args.config_info.target_triple,
     ]);
-    run_command_with_output_and_env(&command, None, Some(&env))?;
+    run_command_with_output_and_env(&command, None, Some(env))?;
 
     // FIXME: create a function "display_if_not_quiet" or something along the line.
     println!("[BUILD] example");
@@ -264,7 +264,7 @@ fn mini_tests(env: &Env, args: &TestArg) -> Result<(), String> {
         &"--target",
         &args.config_info.target_triple,
     ]);
-    run_command_with_output_and_env(&command, None, Some(&env))?;
+    run_command_with_output_and_env(&command, None, Some(env))?;
 
     // FIXME: create a function "display_if_not_quiet" or something along the line.
     println!("[AOT] mini_core_hello_world");
@@ -279,14 +279,14 @@ fn mini_tests(env: &Env, args: &TestArg) -> Result<(), String> {
         &"--target",
         &args.config_info.target_triple,
     ]);
-    run_command_with_output_and_env(&command, None, Some(&env))?;
+    run_command_with_output_and_env(&command, None, Some(env))?;
 
     let command: &[&dyn AsRef<OsStr>] = &[
         &Path::new(&args.config_info.cargo_target_dir).join("mini_core_hello_world"),
         &"abc",
         &"bcd",
     ];
-    maybe_run_command_in_vm(&command, env, args)?;
+    maybe_run_command_in_vm(command, env, args)?;
     Ok(())
 }
 
@@ -512,19 +512,19 @@ fn setup_rustc(env: &mut Env, args: &TestArg) -> Result<PathBuf, String> {
     let cargo = String::from_utf8(
         run_command_with_env(&[&"rustup", &"which", &"cargo"], rust_dir, Some(env))?.stdout,
     )
-    .map_err(|error| format!("Failed to retrieve cargo path: {:?}", error))
+    .map_err(|error| format!("Failed to retrieve cargo path: {error:?}"))
     .and_then(|cargo| {
         let cargo = cargo.trim().to_owned();
-        if cargo.is_empty() { Err(format!("`cargo` path is empty")) } else { Ok(cargo) }
+        if cargo.is_empty() { Err("`cargo` path is empty".to_string()) } else { Ok(cargo) }
     })?;
     let rustc = String::from_utf8(
         run_command_with_env(&[&"rustup", &toolchain, &"which", &"rustc"], rust_dir, Some(env))?
             .stdout,
     )
-    .map_err(|error| format!("Failed to retrieve rustc path: {:?}", error))
+    .map_err(|error| format!("Failed to retrieve rustc path: {error:?}"))
     .and_then(|rustc| {
         let rustc = rustc.trim().to_owned();
-        if rustc.is_empty() { Err(format!("`rustc` path is empty")) } else { Ok(rustc) }
+        if rustc.is_empty() { Err("`rustc` path is empty".to_string()) } else { Ok(rustc) }
     })?;
     let llvm_filecheck = match run_command_with_env(
         &[
@@ -551,7 +551,7 @@ fn setup_rustc(env: &mut Env, args: &TestArg) -> Result<PathBuf, String> {
     let file_path = rust_dir_path.join("config.toml");
     std::fs::write(
         &file_path,
-        &format!(
+        format!(
             r#"change-id = 115898
 
 [rust]
@@ -590,7 +590,7 @@ fn asm_tests(env: &Env, args: &TestArg) -> Result<(), String> {
     let codegen_backend_path = format!(
         "{pwd}/target/{channel}/librustc_codegen_gcc.{dylib_ext}",
         pwd = std::env::current_dir()
-            .map_err(|error| format!("`current_dir` failed: {:?}", error))?
+            .map_err(|error| format!("`current_dir` failed: {error:?}"))?
             .display(),
         channel = args.config_info.channel.as_str(),
         dylib_ext = args.config_info.dylib_ext,
@@ -645,11 +645,11 @@ where
     F: Fn(&[&dyn AsRef<OsStr>], Option<&Path>, &Env) -> Result<(), String>,
 {
     let toolchain = get_toolchain()?;
-    let toolchain_arg = format!("+{}", toolchain);
+    let toolchain_arg = format!("+{toolchain}");
     let rustc_version = String::from_utf8(
         run_command_with_env(&[&args.config_info.rustc_command[0], &"-V"], cwd, Some(env))?.stdout,
     )
-    .map_err(|error| format!("Failed to retrieve rustc version: {:?}", error))?;
+    .map_err(|error| format!("Failed to retrieve rustc version: {error:?}"))?;
     let rustc_toolchain_version = String::from_utf8(
         run_command_with_env(
             &[&args.config_info.rustc_command[0], &toolchain_arg, &"-V"],
@@ -658,20 +658,19 @@ where
         )?
         .stdout,
     )
-    .map_err(|error| format!("Failed to retrieve rustc +toolchain version: {:?}", error))?;
+    .map_err(|error| format!("Failed to retrieve rustc +toolchain version: {error:?}"))?;
 
     if rustc_version != rustc_toolchain_version {
         eprintln!(
-            "rustc_codegen_gcc is built for `{}` but the default rustc version is `{}`.",
-            rustc_toolchain_version, rustc_version,
+            "rustc_codegen_gcc is built for `{rustc_toolchain_version}` but the default rustc version is `{rustc_version}`.",
         );
-        eprintln!("Using `{}`.", rustc_toolchain_version);
+        eprintln!("Using `{rustc_toolchain_version}`.");
     }
     let mut env = env.clone();
     let rustflags = env.get("RUSTFLAGS").cloned().unwrap_or_default();
     env.insert("RUSTDOCFLAGS".to_string(), rustflags);
     let mut cargo_command: Vec<&dyn AsRef<OsStr>> = vec![&"cargo", &toolchain_arg];
-    cargo_command.extend_from_slice(&command);
+    cargo_command.extend_from_slice(command);
     callback(&cargo_command, cwd, &env)
 }
 
@@ -884,7 +883,7 @@ fn contains_ui_error_patterns(file_path: &Path, keep_lto_tests: bool) -> Result<
     // Tests generating errors.
     let file = File::open(file_path)
         .map_err(|error| format!("Failed to read `{}`: {:?}", file_path.display(), error))?;
-    for line in BufReader::new(file).lines().filter_map(|line| line.ok()) {
+    for line in BufReader::new(file).lines().map_while(Result::ok) {
         let line = line.trim();
         if line.is_empty() {
             continue;
@@ -953,7 +952,7 @@ where
 
     if !prepare_files_callback(&rust_path)? {
         // FIXME: create a function "display_if_not_quiet" or something along the line.
-        println!("Keeping all {} tests", test_type);
+        println!("Keeping all {test_type} tests");
     }
 
     if test_type == "ui" {
@@ -985,8 +984,7 @@ where
                         "borrowck",
                         "test-attrs",
                     ]
-                    .iter()
-                    .any(|name| *name == dir_name)
+                    .contains(&dir_name)
                     {
                         remove_dir_all(dir).map_err(|error| {
                             format!("Failed to remove folder `{}`: {:?}", dir.display(), error)
@@ -1041,10 +1039,7 @@ where
         if nb_parts > 0 {
             let current_part = args.current_part.unwrap();
             // FIXME: create a function "display_if_not_quiet" or something along the line.
-            println!(
-                "Splitting ui_test into {} parts (and running part {})",
-                nb_parts, current_part
-            );
+            println!("Splitting ui_test into {nb_parts} parts (and running part {current_part})");
             let out = String::from_utf8(
                 run_command(
                     &[
@@ -1062,7 +1057,7 @@ where
                 )?
                 .stdout,
             )
-            .map_err(|error| format!("Failed to retrieve output of find command: {:?}", error))?;
+            .map_err(|error| format!("Failed to retrieve output of find command: {error:?}"))?;
             let mut files = out
                 .split('\n')
                 .map(|line| line.trim())
@@ -1082,7 +1077,7 @@ where
     }
 
     // FIXME: create a function "display_if_not_quiet" or something along the line.
-    println!("[TEST] rustc {} test suite", test_type);
+    println!("[TEST] rustc {test_type} test suite");
     env.insert("COMPILETEST_FORCE_STAGE0".to_string(), "1".to_string());
 
     let extra =
@@ -1106,7 +1101,7 @@ where
             &"always",
             &"--stage",
             &"0",
-            &format!("tests/{}", test_type),
+            &format!("tests/{test_type}"),
             &"--compiletest-rustc-args",
             &rustc_args,
         ],
@@ -1182,7 +1177,7 @@ fn retain_files_callback<'a>(
             run_command(
                 &[
                     &"find",
-                    &format!("tests/{}", test_type),
+                    &format!("tests/{test_type}"),
                     &"-mindepth",
                     &"1",
                     &"-type",
@@ -1201,7 +1196,7 @@ fn retain_files_callback<'a>(
             run_command(
                 &[
                     &"find",
-                    &format!("tests/{}", test_type),
+                    &format!("tests/{test_type}"),
                     &"-type",
                     &"f",
                     &"-name",
@@ -1216,15 +1211,12 @@ fn retain_files_callback<'a>(
         }
 
         // Putting back only the failing ones.
-        if let Ok(files) = std::fs::read_to_string(&file_path) {
+        if let Ok(files) = std::fs::read_to_string(file_path) {
             for file in files.split('\n').map(|line| line.trim()).filter(|line| !line.is_empty()) {
-                run_command(&[&"git", &"checkout", &"--", &file], Some(&rust_path))?;
+                run_command(&[&"git", &"checkout", &"--", &file], Some(rust_path))?;
             }
         } else {
-            println!(
-                "Failed to read `{}`, not putting back failing {} tests",
-                file_path, test_type
-            );
+            println!("Failed to read `{file_path}`, not putting back failing {test_type} tests");
         }
 
         Ok(true)
@@ -1252,8 +1244,7 @@ fn remove_files_callback<'a>(
                 }
             } else {
                 println!(
-                    "Failed to read `{}`, not putting back failing {} tests",
-                    file_path, test_type
+                    "Failed to read `{file_path}`, not putting back failing {test_type} tests"
                 );
             }
         } else {
@@ -1266,7 +1257,7 @@ fn remove_files_callback<'a>(
                     remove_file(&path)?;
                 }
             } else {
-                println!("Failed to read `{}`, not putting back failing ui tests", file_path);
+                println!("Failed to read `{file_path}`, not putting back failing ui tests");
             }
         }
         Ok(true)

--- a/build_system/src/utils.rs
+++ b/build_system/src/utils.rs
@@ -21,7 +21,7 @@ fn exec_command(
     {
         if let Some(signal) = status.signal() {
             // In case the signal didn't kill the current process.
-            return Err(command_error(input, &cwd, format!("Process received signal {}", signal)));
+            return Err(command_error(input, &cwd, format!("Process received signal {signal}")));
         }
     }
     Ok(status)
@@ -65,18 +65,18 @@ fn check_exit_status(
     );
     let input = input.iter().map(|i| i.as_ref()).collect::<Vec<&OsStr>>();
     if show_err {
-        eprintln!("Command `{:?}` failed", input);
+        eprintln!("Command `{input:?}` failed");
     }
     if let Some(output) = output {
         let stdout = String::from_utf8_lossy(&output.stdout);
         if !stdout.is_empty() {
             error.push_str("\n==== STDOUT ====\n");
-            error.push_str(&*stdout);
+            error.push_str(&stdout);
         }
         let stderr = String::from_utf8_lossy(&output.stderr);
         if !stderr.is_empty() {
             error.push_str("\n==== STDERR ====\n");
-            error.push_str(&*stderr);
+            error.push_str(&stderr);
         }
     }
     Err(error)
@@ -233,7 +233,7 @@ pub fn get_toolchain() -> Result<String, String> {
             if !line.starts_with("channel") {
                 return None;
             }
-            line.split('"').skip(1).next()
+            line.split('"').nth(1)
         })
         .next()
     {
@@ -272,7 +272,7 @@ fn git_clone_inner(
 }
 
 fn get_repo_name(url: &str) -> String {
-    let repo_name = url.split('/').last().unwrap();
+    let repo_name = url.split('/').next_back().unwrap();
     match repo_name.strip_suffix(".git") {
         Some(n) => n.to_string(),
         None => repo_name.to_string(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -4,8 +4,8 @@ use std::convert::TryFrom;
 use std::ops::Deref;
 
 use gccjit::{
-    BinaryOp, Block, ComparisonOp, Context, Function, FunctionType, LValue, Location, RValue,
-    ToRValue, Type, UnaryOp,
+    BinaryOp, Block, ComparisonOp, Context, Function, LValue, Location, RValue, ToRValue, Type,
+    UnaryOp,
 };
 use rustc_abi as abi;
 use rustc_abi::{Align, HasDataLayout, Size, TargetDataLayout, WrappingRange};
@@ -785,7 +785,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
                 let f128_type = self.type_f128();
                 let fmodf128 = self.context.new_function(
                     None,
-                    FunctionType::Extern,
+                    gccjit::FunctionType::Extern,
                     f128_type,
                     &[
                         self.context.new_parameter(None, f128_type, "a"),

--- a/src/intrinsic/llvm.rs
+++ b/src/intrinsic/llvm.rs
@@ -1556,4 +1556,5 @@ pub fn intrinsic<'gcc, 'tcx>(name: &str, cx: &CodegenCx<'gcc, 'tcx>) -> Function
     func
 }
 
+#[cfg(feature = "master")]
 include!("archs.rs");

--- a/src/intrinsic/llvm.rs
+++ b/src/intrinsic/llvm.rs
@@ -1012,7 +1012,7 @@ pub fn intrinsic<'gcc, 'tcx>(name: &str, cx: &CodegenCx<'gcc, 'tcx>) -> Function
     };
     let func = cx.context.get_builtin_function(gcc_name);
     cx.functions.borrow_mut().insert(gcc_name.to_string(), func);
-    return func;
+    func
 }
 
 #[cfg(feature = "master")]

--- a/src/type_.rs
+++ b/src/type_.rs
@@ -302,13 +302,13 @@ impl<'gcc, 'tcx> BaseTypeCodegenMethods for CodegenCx<'gcc, 'tcx> {
     #[cfg_attr(feature = "master", allow(unused_mut))]
     fn type_array(&self, ty: Type<'gcc>, mut len: u64) -> Type<'gcc> {
         #[cfg(not(feature = "master"))]
-        if let Some(struct_type) = ty.is_struct() {
-            if struct_type.get_field_count() == 0 {
-                // NOTE: since gccjit only supports i32 for the array size and libcore's tests uses a
-                // size of usize::MAX in test_binary_search, we workaround this by setting the size to
-                // zero for ZSTs.
-                len = 0;
-            }
+        if let Some(struct_type) = ty.is_struct()
+            && struct_type.get_field_count() == 0
+        {
+            // NOTE: since gccjit only supports i32 for the array size and libcore's tests uses a
+            // size of usize::MAX in test_binary_search, we workaround this by setting the size to
+            // zero for ZSTs.
+            len = 0;
         }
 
         self.context.new_array_type(None, ty, len)

--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -57,10 +57,10 @@ pub fn main_inner(profile: Profile) {
 
     #[cfg(not(feature = "master"))]
     fn filter(filename: &Path) -> bool {
-        if let Some(filename) = filename.to_str() {
-            if filename.ends_with("gep.rs") {
-                return false;
-            }
+        if let Some(filename) = filename.to_str()
+            && filename.ends_with("gep.rs")
+        {
+            return false;
         }
         rust_filter(filename)
     }


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#712.

Fix the following warnings:

```
warning: unused variable: `curr`
  --> src/fuzz/reduce.rs:42:13
   |
42 |     let mut curr = 0;
   |             ^^^^ help: if this is intentional, prefix it with an underscore: `_curr`
   |
   = note: `#[warn(unused_variables)]` on by default

warning: variable does not need to be mutable
  --> src/fuzz/reduce.rs:42:9
   |
42 |     let mut curr = 0;
   |         ----^^^^
   |         |
   |         help: remove this `mut`
   |
   = note: `#[warn(unused_mut)]` on by default

warning: unused `Result` that must be used
   --> src/fuzz/reduce.rs:431:9
    |
431 |         out.write_all(line.as_bytes());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this `Result` may be an `Err` variant, which should be handled
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
431 |         let _ = out.write_all(line.as_bytes());
    |         +++++++

warning: `y` (bin "y") generated 3 warnings (run `cargo fix --bin "y"` to apply 1 suggestion)
```