### PR TITLE
Fixed some clippy warnings.

### DIFF
--- a/build_system/src/abi_test.rs
+++ b/build_system/src/abi_test.rs
@@ -13,13 +13,16 @@ fn show_usage() {
 
 pub fn run() -> Result<(), String> {
     let mut args = std::env::args().skip(2);
+    // FractalFir: In the future, I'd like to add some more subcommands / options.
+    // So, this loop ought to stay for that purpose. It should also stay as a while loop(to parse args)
+    #[allow(clippy::never_loop, clippy::while_let_on_iterator)]
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--help" => {
                 show_usage();
                 return Ok(());
             }
-            _ => return Err(format!("Unknown option {}", arg)),
+            _ => return Err(format!("Unknown option {arg:?}")),
         }
     }
     // Ensure that we have a cloned version of abi-cafe on hand.
@@ -56,7 +59,7 @@ pub fn run() -> Result<(), String> {
         &"c_calls_cg_gcc",
     ];
     // Run ABI cafe.
-    run_command_with_output(cmd, Some(&Path::new("clones/abi-cafe")))?;
+    run_command_with_output(cmd, Some(Path::new("clones/abi-cafe")))?;
 
     Ok(())
 }


### PR DESCRIPTION
Slienced some bogus clippy warnings in `abi_tests`. 

This file is meant to be expanded in the future(by adding options needed for CI runs), and clippy is complaing about some of that scafolding code. 

The warning `clippy::never_loop` is raised because the command only supports one argument(`--help`) which stops argument parsing, and prints a message. So, the loop can only iterate once: by either printing the help, or an error message(for invalid options). This is correct, and the loop is still needed to handle new parameters we will add in the future.

`clippy::while_let_on_iterator`, on the other hand, warns us that this `while` loop could be rewritten as a `for` loop. This is true now, because we don't have any parameters with additional arguments. If we want to add a parameter like this:
`--abi-cafe-config <path>`, we will need to get the path by calling next. This is not possible when using a `for` loop. 