### PR TITLE
Change the implementation of supports_parallel to signal tha cg_gcc is not thread safe.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -289,6 +289,10 @@ fn new_context<'gcc, 'tcx>(tcx: TyCtxt<'tcx>) -> Context<'gcc> {
 }
 
 impl ExtraBackendMethods for GccCodegenBackend {
+    fn supports_parallel(&self) -> bool {
+        false
+    }
+
     fn codegen_allocator(
         &self,
         tcx: TyCtxt<'_>,
@@ -357,8 +361,7 @@ impl Deref for SyncContext {
 }
 
 unsafe impl Send for SyncContext {}
-// FIXME(antoyo): that shouldn't be Sync. Parallel compilation is currently disabled with "-Zno-parallel-llvm".
-// TODO: disable it here by returning false in CodegenBackend::supports_parallel().
+// FIXME(antoyo): that shouldn't be Sync. Parallel compilation is currently disabled with "CodegenBackend::supports_parallel()".
 unsafe impl Sync for SyncContext {}
 
 impl WriteBackendMethods for GccCodegenBackend {


### PR DESCRIPTION
This explicitly disables multithreading in `cg_gcc`. `libgccjit` is not thread-safe, and this option should not have been accidentally enabled in the first place.