### PR TITLE
ci: Don't set `compiler-builtins-no-f16-f128`

### DIFF
--- a/.github/workflows/m68k.yml
+++ b/.github/workflows/m68k.yml
@@ -82,14 +82,14 @@ jobs:
     - name: Build sample project with target defined as JSON spec
       run: |
         ./y.sh prepare --only-libcore --cross
-        ./y.sh build --sysroot --features compiler-builtins-no-f16-f128 --target-triple m68k-unknown-linux-gnu --target ${{ github.workspace }}/target_specs/m68k-unknown-linux-gnu.json
+        ./y.sh build --sysroot --target-triple m68k-unknown-linux-gnu --target ${{ github.workspace }}/target_specs/m68k-unknown-linux-gnu.json
         CG_RUSTFLAGS="-Clinker=m68k-unknown-linux-gnu-gcc" ./y.sh cargo build --manifest-path=./tests/hello-world/Cargo.toml --target ${{ github.workspace }}/target_specs/m68k-unknown-linux-gnu.json
         ./y.sh clean all
 
     - name: Build
       run: |
         ./y.sh prepare --only-libcore --cross
-        ./y.sh build --sysroot --features compiler-builtins-no-f16-f128 --target-triple m68k-unknown-linux-gnu
+        ./y.sh build --sysroot --target-triple m68k-unknown-linux-gnu
         ./y.sh test --mini-tests --target-triple m68k-unknown-linux-gnu
         CG_GCC_TEST_TARGET=m68k-unknown-linux-gnu ./y.sh test --cargo-tests --target-triple m68k-unknown-linux-gnu
         ./y.sh clean all
@@ -102,7 +102,7 @@ jobs:
 
     - name: Run tests
       run: |
-        ./y.sh test --target-triple m68k-unknown-linux-gnu --release --clean --build-sysroot --sysroot-features compiler-builtins-no-f16-f128 ${{ matrix.commands }}
+        ./y.sh test --target-triple m68k-unknown-linux-gnu --release --clean --build-sysroot ${{ matrix.commands }}
 
     - name: Run Hello World!
       run: |

--- a/patches/0001-configure-Use-CARGO_CFG_-_-F16-F128-rather-than-invo.patch
+++ b/patches/0001-configure-Use-CARGO_CFG_-_-F16-F128-rather-than-invo.patch
@@ -1,0 +1,137 @@
+From fbc700f92bdb008a9fd76e2a02230cea6c23d2c4 Mon Sep 17 00:00:00 2001
+From: Trevor Gross <tmgross@umich.edu>
+Date: Tue, 5 Aug 2025 20:56:27 +0000
+Subject: [PATCH] configure: Use `CARGO_CFG_*_{F16,F128}` rather than invoking
+ rustc
+
+Currently we run the `rustc` from the `RUSTC` environment variable to
+figure out whether or not to enable `f16` and `f128`, based on the
+`target_has_reliable_{f16,f128}` config. However, this does not know
+about the codegen backend used, and the backend isn't trivial to check
+in a build script (usually it gets set via `RUSTFLAGS`).
+
+It turns out we don't actually need to run `rustc` here: Cargo
+unconditionally emits all config from the relevant compiler as
+`CARGO_CFG_*` variables, regardless of whether or not they are known
+options. Switch to checking these for setting config rather than
+invoking `rustc`.
+
+As an added advantage, this will work with target.json files without any
+special handling.
+
+Fixes: ed17b95715dd ("Use the compiler to determine whether or not to enable `f16` and `f128`")
+---
+ .../compiler-builtins/configure.rs            | 27 +++--------------
+ library/compiler-builtins/libm/configure.rs   | 30 ++++---------------
+ 2 files changed, 10 insertions(+), 47 deletions(-)
+
+diff --git a/library/compiler-builtins/compiler-builtins/configure.rs b/library/compiler-builtins/compiler-builtins/configure.rs
+index caedc034da6..79e238abc0f 100644
+--- a/library/compiler-builtins/compiler-builtins/configure.rs
++++ b/library/compiler-builtins/compiler-builtins/configure.rs
+@@ -1,6 +1,5 @@
+ // Configuration that is shared between `compiler_builtins` and `builtins_test`.
+ 
+-use std::process::{Command, Stdio};
+ use std::{env, str};
+ 
+ #[derive(Debug)]
+@@ -35,26 +34,6 @@ pub fn from_env() -> Self {
+             .map(|s| s.to_lowercase().replace("_", "-"))
+             .collect();
+ 
+-        // Query rustc for options that Cargo does not provide env for. The bootstrap hack is used
+-        // to get consistent output regardless of channel (`f16`/`f128` config options are hidden
+-        // on stable otherwise).
+-        let mut cmd = Command::new(env::var("RUSTC").unwrap());
+-        cmd.args(["--print=cfg", "--target", &triple])
+-            .env("RUSTC_BOOTSTRAP", "1")
+-            .stderr(Stdio::inherit());
+-        let out = cmd
+-            .output()
+-            .unwrap_or_else(|e| panic!("failed to run `{cmd:?}`: {e}"));
+-        let rustc_cfg = str::from_utf8(&out.stdout).unwrap();
+-
+-        // If we couldn't query `rustc` (e.g. a custom JSON target was used), make the safe
+-        // choice and leave `f16` and `f128` disabled.
+-        let rustc_output_ok = out.status.success();
+-        let reliable_f128 =
+-            rustc_output_ok && rustc_cfg.lines().any(|l| l == "target_has_reliable_f128");
+-        let reliable_f16 =
+-            rustc_output_ok && rustc_cfg.lines().any(|l| l == "target_has_reliable_f16");
+-
+         Self {
+             triple,
+             triple_split,
+@@ -74,8 +53,10 @@ pub fn from_env() -> Self {
+                 .split(",")
+                 .map(ToOwned::to_owned)
+                 .collect(),
+-            reliable_f128,
+-            reliable_f16,
++            // Note that these are unstable options, so only show up with the nightly compiler or
++            // with `RUSTC_BOOTSTRAP=1` (which is required to use the types anyway).
++            reliable_f128: env::var_os("CARGO_CFG_TARGET_HAS_RELIABLE_F128").is_some(),
++            reliable_f16: env::var_os("CARGO_CFG_TARGET_HAS_RELIABLE_F16").is_some(),
+         }
+     }
+ 
+diff --git a/library/compiler-builtins/libm/configure.rs b/library/compiler-builtins/libm/configure.rs
+index f9100d2d58b..76186e63652 100644
+--- a/library/compiler-builtins/libm/configure.rs
++++ b/library/compiler-builtins/libm/configure.rs
+@@ -1,9 +1,9 @@
+ // Configuration shared with both libm and libm-test
+ 
++use std::env;
+ use std::path::PathBuf;
+-use std::process::{Command, Stdio};
+-use std::{env, str};
+ 
++#[derive(Debug)]
+ #[allow(dead_code)]
+ pub struct Config {
+     pub manifest_dir: PathBuf,
+@@ -33,26 +33,6 @@ pub fn from_env() -> Self {
+             .map(|s| s.to_lowercase().replace("_", "-"))
+             .collect();
+ 
+-        // Query rustc for options that Cargo does not provide env for. The bootstrap hack is used
+-        // to get consistent output regardless of channel (`f16`/`f128` config options are hidden
+-        // on stable otherwise).
+-        let mut cmd = Command::new(env::var("RUSTC").unwrap());
+-        cmd.args(["--print=cfg", "--target", &target_triple])
+-            .env("RUSTC_BOOTSTRAP", "1")
+-            .stderr(Stdio::inherit());
+-        let out = cmd
+-            .output()
+-            .unwrap_or_else(|e| panic!("failed to run `{cmd:?}`: {e}"));
+-        let rustc_cfg = str::from_utf8(&out.stdout).unwrap();
+-
+-        // If we couldn't query `rustc` (e.g. a custom JSON target was used), make the safe
+-        // choice and leave `f16` and `f128` disabled.
+-        let rustc_output_ok = out.status.success();
+-        let reliable_f128 =
+-            rustc_output_ok && rustc_cfg.lines().any(|l| l == "target_has_reliable_f128");
+-        let reliable_f16 =
+-            rustc_output_ok && rustc_cfg.lines().any(|l| l == "target_has_reliable_f16");
+-
+         Self {
+             target_triple,
+             manifest_dir: PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap()),
+@@ -66,8 +46,10 @@ pub fn from_env() -> Self {
+             target_string: env::var("TARGET").unwrap(),
+             target_vendor: env::var("CARGO_CFG_TARGET_VENDOR").unwrap(),
+             target_features,
+-            reliable_f128,
+-            reliable_f16,
++            // Note that these are unstable options, so only show up with the nightly compiler or
++            // with `RUSTC_BOOTSTRAP=1` (which is required to use the types anyway).
++            reliable_f128: env::var_os("CARGO_CFG_TARGET_HAS_RELIABLE_F128").is_some(),
++            reliable_f16: env::var_os("CARGO_CFG_TARGET_HAS_RELIABLE_F16").is_some(),
+         }
+     }
+ }
+-- 
+2.48.1
+


### PR DESCRIPTION
Since rust-lang/rust be35d37d8b6c ("Use the compiler to determine whether or not to enable f16 and f128"), `compiler-builtins` relies on `rustc` to report whether or not `f16` and `f128` are supported, which is reported by the backend. This means that there should no longer be any need to set this config in CI.

Backend config: https://github.com/rust-lang/rustc_codegen_gcc/blob/f682d09eefc6700b9e5851ef193847959acf4fac/src/lib.rs#L499-L510