### PR TITLE
Always add git user info to run_command

### DIFF
--- a/build_system/src/prepare.rs
+++ b/build_system/src/prepare.rs
@@ -1,11 +1,48 @@
+use std::ffi::OsStr;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Output;
 
 use crate::rustc_info::get_rustc_path;
 use crate::utils::{
     cargo_install, create_dir, get_sysroot_dir, git_clone_root_dir, remove_file, run_command,
     run_command_with_output, walk_dir,
 };
+
+// This is needed on systems where nothing is configured.
+// git really needs something here, or it will fail.
+// Even using --author is not enough.
+const GIT_CMD: [&dyn AsRef<OsStr>; 9] = [
+    &"git",
+    &"-c",
+    &"user.name=None",
+    &"-c",
+    &"user.email=none@example.com",
+    &"-c",
+    &"core.autocrlf=false",
+    &"-c",
+    &"commit.gpgSign=false",
+];
+
+fn run_git_command(
+    command: &dyn AsRef<OsStr>,
+    input: &[&dyn AsRef<OsStr>],
+    cwd: Option<&Path>,
+) -> Result<Output, String> {
+    let git_cmd =
+        &GIT_CMD.into_iter().chain([command]).chain(input.iter().cloned()).collect::<Vec<_>>()[..];
+    run_command(git_cmd, cwd)
+}
+
+fn run_git_command_with_output(
+    command: &dyn AsRef<OsStr>,
+    input: &[&dyn AsRef<OsStr>],
+    cwd: Option<&Path>,
+) -> Result<(), String> {
+    let git_cmd =
+        &GIT_CMD.into_iter().chain([command]).chain(input.iter().cloned()).collect::<Vec<_>>()[..];
+    run_command_with_output(git_cmd, cwd)
+}
 
 fn prepare_libcore(
     sysroot_path: &Path,
@@ -55,19 +92,12 @@ fn prepare_libcore(
     run_command(&[&"cp", &"-r", &rustlib_dir.join("library"), &sysroot_dir], None)?;
 
     println!("[GIT] init (cwd): `{}`", sysroot_dir.display());
-    run_command(&[&"git", &"init"], Some(&sysroot_dir))?;
+    run_git_command(&"init", &[], Some(&sysroot_dir))?;
     println!("[GIT] add (cwd): `{}`", sysroot_dir.display());
-    run_command(&[&"git", &"add", &"."], Some(&sysroot_dir))?;
+    run_git_command(&"add", &[&"."], Some(&sysroot_dir))?;
     println!("[GIT] commit (cwd): `{}`", sysroot_dir.display());
 
-    // This is needed on systems where nothing is configured.
-    // git really needs something here, or it will fail.
-    // Even using --author is not enough.
-    run_command(&[&"git", &"config", &"user.email", &"none@example.com"], Some(&sysroot_dir))?;
-    run_command(&[&"git", &"config", &"user.name", &"None"], Some(&sysroot_dir))?;
-    run_command(&[&"git", &"config", &"core.autocrlf", &"false"], Some(&sysroot_dir))?;
-    run_command(&[&"git", &"config", &"commit.gpgSign", &"false"], Some(&sysroot_dir))?;
-    run_command(&[&"git", &"commit", &"-m", &"Initial commit", &"-q"], Some(&sysroot_dir))?;
+    run_git_command(&"commit", &[&"-m", &"Initial commit", &"-q"], Some(&sysroot_dir))?;
 
     let mut patches = Vec::new();
     walk_dir(
@@ -105,10 +135,11 @@ fn prepare_libcore(
     for file_path in patches {
         println!("[GIT] apply `{}`", file_path.display());
         let path = Path::new("../../..").join(file_path);
-        run_command_with_output(&[&"git", &"apply", &path], Some(&sysroot_dir))?;
-        run_command_with_output(&[&"git", &"add", &"-A"], Some(&sysroot_dir))?;
-        run_command_with_output(
-            &[&"git", &"commit", &"--no-gpg-sign", &"-m", &format!("Patch {}", path.display())],
+        run_git_command_with_output(&"apply", &[&path], Some(&sysroot_dir))?;
+        run_git_command_with_output(&"add", &[&"-A"], Some(&sysroot_dir))?;
+        run_git_command_with_output(
+            &"commit",
+            &[&"-m", &format!("Patch {}", path.display())],
             Some(&sysroot_dir),
         )?;
     }
@@ -124,10 +155,11 @@ fn prepare_rand() -> Result<(), String> {
     let rand_dir = Path::new("build/rand");
     println!("[GIT] apply `{file_path}`");
     let path = Path::new("../..").join(file_path);
-    run_command_with_output(&[&"git", &"apply", &path], Some(rand_dir))?;
-    run_command_with_output(&[&"git", &"add", &"-A"], Some(rand_dir))?;
-    run_command_with_output(
-        &[&"git", &"commit", &"--no-gpg-sign", &"-m", &format!("Patch {}", path.display())],
+    run_git_command_with_output(&"apply", &[&path], Some(rand_dir))?;
+    run_git_command_with_output(&"add", &[&"-A"], Some(rand_dir))?;
+    run_git_command_with_output(
+        &"commit",
+        &[&"-m", &format!("Patch {}", path.display())],
         Some(rand_dir),
     )?;
 
@@ -154,8 +186,8 @@ where
         println!("`{}` has already been cloned", clone_result.repo_name);
     }
     let repo_path = Path::new(crate::BUILD_DIR).join(&clone_result.repo_name);
-    run_command(&[&"git", &"checkout", &"--", &"."], Some(&repo_path))?;
-    run_command(&[&"git", &"checkout", &checkout_commit], Some(&repo_path))?;
+    run_git_command(&"checkout", &[&"--", &"."], Some(&repo_path))?;
+    run_git_command(&"checkout", &[&checkout_commit], Some(&repo_path))?;
     if let Some(extra) = extra {
         extra(&repo_path)?;
     }

--- a/build_system/src/utils.rs
+++ b/build_system/src/utils.rs
@@ -112,8 +112,7 @@ pub fn run_command_with_output(
     cwd: Option<&Path>,
 ) -> Result<(), String> {
     let exit_status = exec_command(input, cwd, None)?;
-    check_exit_status(input, cwd, exit_status, None, true)?;
-    Ok(())
+    check_exit_status(input, cwd, exit_status, None, true)
 }
 
 pub fn run_command_with_output_and_env(
@@ -122,8 +121,7 @@ pub fn run_command_with_output_and_env(
     env: Option<&HashMap<String, String>>,
 ) -> Result<(), String> {
     let exit_status = exec_command(input, cwd, env)?;
-    check_exit_status(input, cwd, exit_status, None, true)?;
-    Ok(())
+    check_exit_status(input, cwd, exit_status, None, true)
 }
 
 #[cfg(not(unix))]
@@ -133,8 +131,7 @@ pub fn run_command_with_output_and_env_no_err(
     env: Option<&HashMap<String, String>>,
 ) -> Result<(), String> {
     let exit_status = exec_command(input, cwd, env)?;
-    check_exit_status(input, cwd, exit_status, None, false)?;
-    Ok(())
+    check_exit_status(input, cwd, exit_status, None, false)
 }
 
 pub fn cargo_install(to_install: &str) -> Result<(), String> {


### PR DESCRIPTION
This PR always pass the `user.name`, `user.email`, `core.autocrlf` and `commit.gpgSign` git parameters to the `run_command` and `run_command_with_output` functions.

With this PR, I managed to successfully run `./y.sh prepare` after a `./y.sh clean all" with and without `user.name` and `user.email` parameters defined for the repo.

Fixes rust-lang/rustc_codegen_gcc#731 