### PR TITLE
Add `dejagnu` to the quickstart installation command line

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,7 +57,7 @@ To build it (most of these instructions come from [here](https://gcc.gnu.org/onl
 
 ```bash
 $ git clone https://github.com/rust-lang/gcc
-$ sudo apt install flex libmpfr-dev libgmp-dev libmpc3 libmpc-dev
+$ sudo apt install flex libmpfr-dev libgmp-dev libmpc3 libmpc-dev dejagnu
 $ mkdir gcc-build gcc-install
 $ cd gcc-build
 $ ../gcc/configure \


### PR DESCRIPTION
Hey, I was trying to run the tests for my own GCC version by following [these instructions](https://github.com/rust-lang/rustc_codegen_gcc/blob/5cb8d34d638c11a117d77bf0d39cfed15c4c7215/Readme.md#building-with-your-own-gcc-version).

I overlooked the [Dependencies](https://github.com/rust-lang/rustc_codegen_gcc/blob/5cb8d34d638c11a117d77bf0d39cfed15c4c7215/Readme.md#dependencies) part, which led `make check-jit` to fail due to `runtest` not being found. This is a RTFM on my part of course, but I thought it would be helpful to add `dejagnu` to the quickstart installation command line to avoid this in the future.