### PR TITLE
Implement reg vector type

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -88,7 +88,7 @@ impl GccType for Reg {
                 64 => cx.type_f64(),
                 _ => bug!("unsupported float: {:?}", self),
             },
-            RegKind::Vector => unimplemented!(), //cx.type_vector(cx.type_i8(), self.size.bytes()),
+            RegKind::Vector => cx.type_vector(cx.type_i8(), self.size.bytes()),
         }
     }
 }


### PR DESCRIPTION
Fix rust-lang/rustc_codegen_gcc#784