### PR TITLE
Move libgccjit.so in the sysroot

### DIFF
--- a/.github/workflows/failures.yml
+++ b/.github/workflows/failures.yml
@@ -54,8 +54,6 @@ jobs:
       if: matrix.libgccjit_version.gcc == 'libgccjit12.so'
       run: |
           echo 'gcc-path = "/usr/lib/gcc/x86_64-linux-gnu/12"' > config.toml
-          echo "LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/12" >> $GITHUB_ENV
-          echo "LD_LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/12" >> $GITHUB_ENV
 
     - name: Download artifact
       if: matrix.libgccjit_version.gcc != 'libgccjit12.so'

--- a/.github/workflows/gcc12.yml
+++ b/.github/workflows/gcc12.yml
@@ -51,12 +51,6 @@ jobs:
     - name: Setup path to libgccjit
       run: echo 'gcc-path = "/usr/lib/gcc/x86_64-linux-gnu/12"' > config.toml
 
-    - name: Set env
-      run: |
-        echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
-        echo "LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/12" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=/usr/lib/gcc/x86_64-linux-gnu/12" >> $GITHUB_ENV
-
     #- name: Cache rust repository
       ## We only clone the rust repository for rustc tests
       #if: ${{ contains(matrix.commands, 'rustc') }}

--- a/.github/workflows/stdarch.yml
+++ b/.github/workflows/stdarch.yml
@@ -59,21 +59,14 @@ jobs:
           sudo ln -s /usr/share/intel-sde/sde /usr/bin/sde
           sudo ln -s /usr/share/intel-sde/sde64 /usr/bin/sde64
 
-    - name: Set env
+    - name: Set config
       run: |
-        echo "workspace="$GITHUB_WORKSPACE >> $GITHUB_ENV
         echo 'download-gccjit = true' > config.toml
 
     - name: Build
       run: |
         ./y.sh prepare --only-libcore
         ./y.sh build --sysroot --release --release-sysroot
-
-    - name: Set env (part 2)
-      run: |
-        # Set the `LD_LIBRARY_PATH` and `LIBRARY_PATH` env variables...
-        echo "LD_LIBRARY_PATH="$(./y.sh info | grep -v Using) >> $GITHUB_ENV
-        echo "LIBRARY_PATH="$(./y.sh info | grep -v Using) >> $GITHUB_ENV
 
     - name: Clean
       if: ${{ !matrix.cargo_runner }}

--- a/build_system/src/config.rs
+++ b/build_system/src/config.rs
@@ -429,19 +429,6 @@ impl ConfigInfo {
         // display metadata load errors
         env.insert("RUSTC_LOG".to_string(), "warn".to_string());
 
-        let sysroot = current_dir
-            .join(get_sysroot_dir())
-            .join(format!("sysroot/lib/rustlib/{}/lib", self.target_triple));
-        let ld_library_path = format!(
-            "{target}:{sysroot}:{gcc_path}",
-            target = self.cargo_target_dir,
-            sysroot = sysroot.display(),
-            gcc_path = gcc_path,
-        );
-        env.insert("LIBRARY_PATH".to_string(), ld_library_path.clone());
-        env.insert("LD_LIBRARY_PATH".to_string(), ld_library_path.clone());
-        env.insert("DYLD_LIBRARY_PATH".to_string(), ld_library_path);
-
         // NOTE: To avoid the -fno-inline errors, use /opt/gcc/bin/gcc instead of cc.
         // To do so, add a symlink for cc to /opt/gcc/bin/gcc in our PATH.
         // Another option would be to add the following Rust flag: -Clinker=/opt/gcc/bin/gcc

--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -215,14 +215,6 @@ fn cargo_tests(test_env: &Env, test_args: &TestArg) -> Result<(), String> {
     // That would force `cg_gcc` to *rebuild itself* and only then run tests, which is undesirable.
     let mut env = HashMap::new();
     env.insert(
-        "LD_LIBRARY_PATH".into(),
-        test_env.get("LD_LIBRARY_PATH").expect("LD_LIBRARY_PATH missing!").to_string(),
-    );
-    env.insert(
-        "LIBRARY_PATH".into(),
-        test_env.get("LIBRARY_PATH").expect("LIBRARY_PATH missing!").to_string(),
-    );
-    env.insert(
         "CG_RUSTFLAGS".into(),
         test_env.get("CG_RUSTFLAGS").map(|s| s.as_str()).unwrap_or("").to_string(),
     );
@@ -1276,11 +1268,6 @@ pub fn run() -> Result<(), String> {
 
     if !args.use_system_gcc {
         args.config_info.setup_gcc_path()?;
-        let gcc_path = args.config_info.gcc_path.clone().expect(
-            "The config module should have emitted an error if the GCC path wasn't provided",
-        );
-        env.insert("LIBRARY_PATH".to_string(), gcc_path.clone());
-        env.insert("LD_LIBRARY_PATH".to_string(), gcc_path);
     }
 
     build_if_no_backend(&env, &args)?;

--- a/tests/lang_tests_common.rs
+++ b/tests/lang_tests_common.rs
@@ -2,11 +2,10 @@
 
 #![allow(clippy::uninlined_format_args)]
 
-use std::env::{self, current_dir};
+use std::env::current_dir;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use boml::Toml;
 use lang_tester::LangTester;
 use tempfile::TempDir;
 
@@ -22,29 +21,6 @@ pub fn main_inner(profile: Profile) {
     let tempdir = TempDir::new().expect("temp dir");
     let current_dir = current_dir().expect("current dir");
     let current_dir = current_dir.to_str().expect("current dir").to_string();
-
-    let manifest_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
-
-    let gcc_path = std::fs::read_to_string(manifest_dir.join("config.toml"))
-        .ok()
-        .and_then(|v| {
-            let toml = Toml::parse(&v).expect("Failed to parse `config.toml`");
-            toml.get_string("gcc-path").map(PathBuf::from).ok()
-        })
-        .unwrap_or_else(|| {
-            // then we try to retrieve it from the `target` folder.
-            let commit = include_str!("../libgccjit.version").trim();
-            Path::new("build/libgccjit").join(commit)
-        });
-
-    let gcc_path = Path::new(&gcc_path)
-        .canonicalize()
-        .expect("failed to get absolute path of `gcc-path`")
-        .display()
-        .to_string();
-    unsafe {
-        env::set_var("LD_LIBRARY_PATH", gcc_path);
-    }
 
     fn rust_filter(path: &Path) -> bool {
         path.is_file() && path.extension().expect("extension").to_str().expect("to_str") == "rs"


### PR DESCRIPTION
This will be useful for the unification work of the handling of the library between all Rust setups.