### PR TITLE
Remove `[no-mentions]` handler in our triagebot config

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,6 +2,3 @@
 
 # Prevents un-canonicalized issue links (to avoid wrong issues being linked in r-l/rust)
 [issue-links]
-
-# Prevents mentions in commits to avoid users being spammed
-[no-mentions]


### PR DESCRIPTION
This PR removes the `[no-mentions]` handler in our triagebot config as [GitHub is removing notifications for @-mentions in commit messages on December 8th 2025.](https://github.blog/changelog/2025-11-07-removing-notifications-for-mentions-in-commit-messages/)

cf. https://github.com/rust-lang/triagebot/issues/2225