### PR TITLE
Fix ICE when calling transmuted function pointers

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -222,15 +222,8 @@ impl<'gcc, 'tcx> FnAbiGccExt<'gcc, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
 
     fn ptr_to_gcc_type(&self, cx: &CodegenCx<'gcc, 'tcx>) -> Type<'gcc> {
         // FIXME(antoyo): Should we do something with `FnAbiGcc::fn_attributes`?
-        let FnAbiGcc { return_type, arguments_type, is_c_variadic, on_stack_param_indices, .. } =
-            self.gcc_type(cx);
-        let pointer_type =
-            cx.context.new_function_pointer_type(None, return_type, &arguments_type, is_c_variadic);
-        cx.on_stack_params.borrow_mut().insert(
-            pointer_type.dyncast_function_ptr_type().expect("function ptr type"),
-            on_stack_param_indices,
-        );
-        pointer_type
+        let FnAbiGcc { return_type, arguments_type, is_c_variadic, .. } = self.gcc_type(cx);
+        cx.context.new_function_pointer_type(None, return_type, &arguments_type, is_c_variadic)
     }
 
     #[cfg(feature = "master")]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -354,14 +354,12 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         args: &[RValue<'gcc>],
         _funclet: Option<&Funclet>,
     ) -> RValue<'gcc> {
-        let gcc_func = match func_ptr.get_type().dyncast_function_ptr_type() {
-            Some(func) => func,
-            None => {
-                // NOTE: due to opaque pointers now being used, we need to cast here.
-                let new_func_type = typ.dyncast_function_ptr_type().expect("function ptr");
-                func_ptr = self.context.new_cast(self.location, func_ptr, typ);
-                new_func_type
-            }
+        let gcc_func = if func_ptr.get_type() != typ {
+            let new_func_type = typ.dyncast_function_ptr_type().expect("function ptr");
+            func_ptr = self.context.new_cast(self.location, func_ptr, typ);
+            new_func_type
+        } else {
+            func_ptr.get_type().dyncast_function_ptr_type().expect("function ptr")
         };
         let func_name = format!("{:?}", func_ptr);
         let previous_arg_count = args.len();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -354,13 +354,16 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         args: &[RValue<'gcc>],
         _funclet: Option<&Funclet>,
     ) -> RValue<'gcc> {
-        let gcc_func = if func_ptr.get_type() != typ {
-            let new_func_type = typ.dyncast_function_ptr_type().expect("function ptr");
-            func_ptr = self.context.new_cast(self.location, func_ptr, typ);
-            new_func_type
-        } else {
-            func_ptr.get_type().dyncast_function_ptr_type().expect("function ptr")
+        let func_ptr_type = {
+            let func_ptr_type = func_ptr.get_type();
+            if func_ptr_type != typ {
+                func_ptr = self.context.new_cast(self.location, func_ptr, typ);
+                typ
+            } else {
+                func_ptr_type
+            }
         };
+        let gcc_func = func_ptr_type.dyncast_function_ptr_type().expect("function ptr");
         let func_name = format!("{:?}", func_ptr);
         let previous_arg_count = args.len();
         let orig_args = args;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -32,6 +32,7 @@ use rustc_span::def_id::DefId;
 use rustc_target::callconv::FnAbi;
 use rustc_target::spec::{HasTargetSpec, HasX86AbiOpt, Target, X86Abi};
 
+use crate::abi::FnAbiGccExt;
 use crate::common::{SignType, TypeReflection, type_is_pointer};
 use crate::context::CodegenCx;
 use crate::errors;
@@ -212,6 +213,7 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         _typ: &str,
         func_ptr: RValue<'gcc>,
         args: &'b [RValue<'gcc>],
+        on_stack_param_indices: &FxHashSet<usize>,
     ) -> Cow<'b, [RValue<'gcc>]> {
         let mut all_args_match = true;
         let mut param_types = vec![];
@@ -222,11 +224,6 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
                 all_args_match = false;
             }
             param_types.push(param);
-        }
-
-        let mut on_stack_param_indices = FxHashSet::default();
-        if let Some(indices) = self.on_stack_params.borrow().get(&gcc_func) {
-            on_stack_param_indices.clone_from(indices);
         }
 
         if all_args_match {
@@ -350,6 +347,7 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
     fn function_ptr_call(
         &mut self,
         typ: Type<'gcc>,
+        fn_abi: Option<&FnAbi<'tcx, Ty<'tcx>>>,
         mut func_ptr: RValue<'gcc>,
         args: &[RValue<'gcc>],
         _funclet: Option<&Funclet>,
@@ -364,6 +362,11 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
             }
         };
         let gcc_func = func_ptr_type.dyncast_function_ptr_type().expect("function ptr");
+        let on_stack_param_indices = if let Some(fn_abi) = fn_abi {
+            fn_abi.gcc_type(self.cx).on_stack_param_indices
+        } else {
+            self.on_stack_params.borrow().get(&gcc_func).cloned().unwrap_or_default()
+        };
         let func_name = format!("{:?}", func_ptr);
         let previous_arg_count = args.len();
         let orig_args = args;
@@ -372,7 +375,7 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
             llvm::adjust_intrinsic_arguments(self, gcc_func, args.into(), &func_name)
         };
         let args_adjusted = args.len() != previous_arg_count;
-        let args = self.check_ptr_call("call", func_ptr, &args);
+        let args = self.check_ptr_call("call", func_ptr, &args, &on_stack_param_indices);
 
         // gccjit requires to use the result of functions, even when it's not used.
         // That's why we assign the result to a local or call add_eval().
@@ -1777,7 +1780,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
             self.function_call(func, args, funclet)
         } else {
             // If it's a not function that was defined, it's a function pointer.
-            self.function_ptr_call(typ, func, args, funclet)
+            self.function_ptr_call(typ, fn_abi, func, args, funclet)
         };
         if let Some(_fn_abi) = fn_abi {
             // FIXME(bjorn3): Apply function attributes

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -362,11 +362,9 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
             }
         };
         let gcc_func = func_ptr_type.dyncast_function_ptr_type().expect("function ptr");
-        let on_stack_param_indices = if let Some(fn_abi) = fn_abi {
-            fn_abi.gcc_type(self.cx).on_stack_param_indices
-        } else {
-            self.on_stack_params.borrow().get(&gcc_func).cloned().unwrap_or_default()
-        };
+        let on_stack_param_indices = fn_abi
+            .map(|fn_abi| fn_abi.gcc_type(self.cx).on_stack_param_indices)
+            .unwrap_or_default();
         let func_name = format!("{:?}", func_ptr);
         let previous_arg_count = args.len();
         let orig_args = args;
@@ -614,7 +612,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
 
         let current_block = self.block;
         self.block = try_block;
-        let call = self.call(typ, fn_attrs, None, func, args, None, instance); // FIXME(antoyo): use funclet here?
+        let call = self.call(typ, fn_attrs, _fn_abi, func, args, None, instance); // FIXME(antoyo): use funclet here?
         self.block = current_block;
 
         let return_value =
@@ -648,7 +646,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         _funclet: Option<&Funclet>,
         instance: Option<Instance<'tcx>>,
     ) -> RValue<'gcc> {
-        let call_site = self.call(typ, fn_attrs, None, func, args, None, instance);
+        let call_site = self.call(typ, fn_attrs, fn_abi, func, args, None, instance);
         let condition = self.context.new_rvalue_from_int(self.bool_type, 1);
         self.llbb().end_with_conditional(self.location, condition, then, catch);
         if let Some(_fn_abi) = fn_abi {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -600,7 +600,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         &mut self,
         typ: Type<'gcc>,
         fn_attrs: Option<&CodegenFnAttrs>,
-        _fn_abi: Option<&FnAbi<'tcx, Ty<'tcx>>>,
+        fn_abi: Option<&FnAbi<'tcx, Ty<'tcx>>>,
         func: RValue<'gcc>,
         args: &[RValue<'gcc>],
         then: Block<'gcc>,
@@ -612,7 +612,7 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
 
         let current_block = self.block;
         self.block = try_block;
-        let call = self.call(typ, fn_attrs, _fn_abi, func, args, None, instance); // FIXME(antoyo): use funclet here?
+        let call = self.call(typ, fn_attrs, fn_abi, func, args, None, instance); // FIXME(antoyo): use funclet here?
         self.block = current_block;
 
         let return_value =

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,7 @@
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 
-use gccjit::{
-    Block, CType, Context, Function, FunctionPtrType, FunctionType, LValue, Location, RValue, Type,
-};
+use gccjit::{Block, CType, Context, Function, FunctionType, LValue, Location, RValue, Type};
 use rustc_abi::{Align, HasDataLayout, PointeeInfo, Size, TargetDataLayout, VariantIdx};
 use rustc_codegen_ssa::base::wants_msvc_seh;
 use rustc_codegen_ssa::errors as ssa_errors;
@@ -100,8 +98,6 @@ pub struct CodegenCx<'gcc, 'tcx> {
         RefCell<FxHashMap<(Ty<'tcx>, Option<ty::ExistentialTraitRef<'tcx>>), RValue<'gcc>>>,
 
     // FIXME(antoyo): improve the SSA API to not require those.
-    /// Mapping from function pointer type to indexes of on stack parameters.
-    pub on_stack_params: RefCell<FxHashMap<FunctionPtrType<'gcc>, FxHashSet<usize>>>,
     /// Mapping from function to indexes of on stack parameters.
     pub on_stack_function_params: RefCell<FxHashMap<Function<'gcc>, FxHashSet<usize>>>,
 
@@ -289,7 +285,6 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             instances: Default::default(),
             function_instances: Default::default(),
             intrinsic_instances: Default::default(),
-            on_stack_params: Default::default(),
             on_stack_function_params: Default::default(),
             vtables: Default::default(),
             const_globals: Default::default(),

--- a/tests/compile/fn_ptr_transmute_ignored_arg.rs
+++ b/tests/compile/fn_ptr_transmute_ignored_arg.rs
@@ -4,6 +4,7 @@
 
 #![crate_type = "lib"]
 
+#[unsafe(no_mangle)]
 extern "C" fn third(_a: usize, b: usize, c: usize) {
     let throw_away_f: fn((), usize, usize) =
         unsafe { std::mem::transmute(third as extern "C" fn(_, _, _)) };

--- a/tests/compile/fn_ptr_transmute_ignored_arg.rs
+++ b/tests/compile/fn_ptr_transmute_ignored_arg.rs
@@ -1,11 +1,11 @@
 // Compiler:
 
+// Regression test for <https://github.com/rust-lang/rustc_codegen_gcc/issues/836>
+
+#![crate_type = "lib"]
+
 extern "C" fn third(_a: usize, b: usize, c: usize) {
     let throw_away_f: fn((), usize, usize) =
         unsafe { std::mem::transmute(third as extern "C" fn(_, _, _)) };
-    throw_away_f((), b, c)
-}
-
-fn main() {
-    third(1, 2, 3);
+    throw_away_f((), 2, 3)
 }

--- a/tests/compile/fn_ptr_transmute_ignored_arg.rs
+++ b/tests/compile/fn_ptr_transmute_ignored_arg.rs
@@ -1,0 +1,11 @@
+// Compiler:
+
+extern "C" fn third(_a: usize, b: usize, c: usize) {
+    let throw_away_f: fn((), usize, usize) =
+        unsafe { std::mem::transmute(third as extern "C" fn(_, _, _)) };
+    throw_away_f((), b, c)
+}
+
+fn main() {
+    third(1, 2, 3);
+}

--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -47,7 +47,6 @@ tests/ui/sanitizer/cfi/virtual-auto.rs
 tests/ui/sanitizer/cfi/sized-associated-ty.rs
 tests/ui/sanitizer/cfi/can-reveal-opaques.rs
 tests/ui/sanitizer/kcfi-mangling.rs
-tests/ui/backtrace/dylib-dep.rs
 tests/ui/delegation/fn-header.rs
 tests/ui/consts/const-eval/parse_ints.rs
 tests/ui/simd/intrinsic/generic-as.rs


### PR DESCRIPTION
Indirect calls could keep the original libgccjit function-pointer type after a transmute instead of the ABI-lowered type expected at the call site, so ZST-elided arguments made libgccjit see the wrong arity and ICE. Cast the callee to the call-site function-pointer type before emitting the indirect call so argument checking and codegen use the normalized signature.

Closes: rust-lang/rustc_codegen_gcc#836