### PR TITLE
Fix asm pointer inputs

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -362,7 +362,7 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                         let ty = value.layout.gcc_type(self.cx);
                         let reg_var = self.current_func().new_local(None, ty, "input_register");
                         reg_var.set_register_name(reg_name);
-                        // TODO: We should remove this when switching to "untyped" pointers
+                        // FIXME: We should remove this when switching to "untyped" pointers
                         let value = value.immediate();
                         let value = if value.get_type() != ty {
                             self.context.new_cast(None, value, ty)

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -362,7 +362,13 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                         let ty = value.layout.gcc_type(self.cx);
                         let reg_var = self.current_func().new_local(None, ty, "input_register");
                         reg_var.set_register_name(reg_name);
-                        self.llbb().add_assignment(None, reg_var, value.immediate());
+                        let value = value.immediate();
+                        let value = if value.get_type() != ty {
+                            self.context.new_cast(None, value, ty)
+                        } else {
+                            value
+                        };
+                        self.llbb().add_assignment(None, reg_var, value);
 
                         inputs.push(AsmInOperand {
                             constraint: "r".into(),

--- a/src/asm.rs
+++ b/src/asm.rs
@@ -362,6 +362,7 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                         let ty = value.layout.gcc_type(self.cx);
                         let reg_var = self.current_func().new_local(None, ty, "input_register");
                         reg_var.set_register_name(reg_name);
+                        // TODO: We should remove this when switching to "untyped" pointers
                         let value = value.immediate();
                         let value = if value.get_type() != ty {
                             self.context.new_cast(None, value, ty)

--- a/tests/run/asm.rs
+++ b/tests/run/asm.rs
@@ -190,6 +190,14 @@ fn asm() {
     }
     assert_eq!((x, y), (8, 8));
 
+    // Regression test for <https://github.com/rust-lang/rustc_codegen_gcc/issues/792>
+    // typed pointer inputs to explicit registers need a cast.
+    let mut x = 123_i32;
+    unsafe {
+        asm!("", in("rdi") &mut x, options(nostack, preserves_flags));
+    }
+    assert_eq!(x, 123);
+
     // sysv64 is the default calling convention on unix systems. The rdi register is
     // used to pass arguments in the sysv64 calling convention, so this register will be clobbered
     #[cfg(unix)]


### PR DESCRIPTION
Typed pointer inputs to explicit registers need a cast.

Closes rust-lang/rustc_codegen_gcc#792