### PR TITLE
fix: handle zero-sized memory intrinsics

### DIFF
--- a/example/mini_core.rs
+++ b/example/mini_core.rs
@@ -662,6 +662,8 @@ pub mod intrinsics {
     #[rustc_intrinsic]
     pub unsafe fn copy<T>(src: *const T, dst: *mut T, count: usize);
     #[rustc_intrinsic]
+    pub unsafe fn copy_nonoverlapping<T>(src: *const T, dst: *mut T, count: usize);
+    #[rustc_intrinsic]
     pub unsafe fn transmute<T, U>(e: T) -> U;
     #[rustc_intrinsic]
     pub unsafe fn ctlz_nonzero<T>(x: T) -> u32;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -63,6 +63,30 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
         self.value_counter.get()
     }
 
+    fn with_non_zero_size(
+        &mut self,
+        size: RValue<'gcc>,
+        builtin_block_name: &str,
+        emit_builtin: impl FnOnce(&mut Self),
+    ) {
+        let size_is_zero = self.context.new_comparison(
+            self.location,
+            ComparisonOp::Equals,
+            size,
+            self.const_usize(0),
+        );
+        let func = self.current_func();
+        let builtin_block = func.new_block(builtin_block_name);
+        let after_block = func.new_block("after_memory_builtin");
+        self.llbb().end_with_conditional(self.location, size_is_zero, after_block, builtin_block);
+
+        self.switch_to_block(builtin_block);
+        emit_builtin(self);
+        self.llbb().end_with_jump(self.location, after_block);
+
+        self.switch_to_block(after_block);
+    }
+
     fn atomic_extremum(
         &mut self,
         operation: ExtremumOperation,
@@ -1404,12 +1428,12 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         let _is_volatile = flags.contains(MemFlags::VOLATILE);
         let dst = self.pointercast(dst, self.type_i8p());
         let src = self.pointercast(src, self.type_ptr_to(self.type_void()));
-        let memcpy = self.context.get_builtin_function("memcpy");
-        // FIXME(antoyo): handle aligns and is_volatile.
-        self.block.add_eval(
-            self.location,
-            self.context.new_call(self.location, memcpy, &[dst, src, size]),
-        );
+        self.with_non_zero_size(size, "memcpy", |bx| {
+            let memcpy = bx.context.get_builtin_function("memcpy");
+            // FIXME(antoyo): handle aligns and is_volatile.
+            bx.block
+                .add_eval(bx.location, bx.context.new_call(bx.location, memcpy, &[dst, src, size]));
+        });
     }
 
     fn memmove(
@@ -1427,12 +1451,14 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         let dst = self.pointercast(dst, self.type_i8p());
         let src = self.pointercast(src, self.type_ptr_to(self.type_void()));
 
-        let memmove = self.context.get_builtin_function("memmove");
-        // FIXME(antoyo): handle is_volatile.
-        self.block.add_eval(
-            self.location,
-            self.context.new_call(self.location, memmove, &[dst, src, size]),
-        );
+        self.with_non_zero_size(size, "memmove", |bx| {
+            let memmove = bx.context.get_builtin_function("memmove");
+            // FIXME(antoyo): handle is_volatile.
+            bx.block.add_eval(
+                bx.location,
+                bx.context.new_call(bx.location, memmove, &[dst, src, size]),
+            );
+        });
     }
 
     fn memset(
@@ -1446,14 +1472,16 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         assert!(!flags.contains(MemFlags::NONTEMPORAL), "non-temporal memset not supported");
         let _is_volatile = flags.contains(MemFlags::VOLATILE);
         let ptr = self.pointercast(ptr, self.type_i8p());
-        let memset = self.context.get_builtin_function("memset");
         // FIXME(antoyo): handle align and is_volatile.
         let fill_byte = self.context.new_cast(self.location, fill_byte, self.i32_type);
         let size = self.intcast(size, self.type_size_t(), false);
-        self.block.add_eval(
-            self.location,
-            self.context.new_call(self.location, memset, &[ptr, fill_byte, size]),
-        );
+        self.with_non_zero_size(size, "memset", |bx| {
+            let memset = bx.context.get_builtin_function("memset");
+            bx.block.add_eval(
+                bx.location,
+                bx.context.new_call(bx.location, memset, &[ptr, fill_byte, size]),
+            );
+        });
     }
 
     fn select(

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -338,13 +338,6 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                 );
                 return Ok(());
             }
-            sym::copy | sym::copy_nonoverlapping | sym::write_bytes => {
-                let ty = fn_args.type_at(0);
-                if self.layout_of(ty).size.bytes() == 0 {
-                    return Ok(());
-                }
-                return Err(Instance::new_raw(instance.def_id(), instance.args));
-            }
             sym::breakpoint => {
                 unimplemented!();
             }

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -338,6 +338,13 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
                 );
                 return Ok(());
             }
+            sym::copy | sym::copy_nonoverlapping | sym::write_bytes => {
+                let ty = fn_args.type_at(0);
+                if self.layout_of(ty).size.bytes() == 0 {
+                    return Ok(());
+                }
+                return Err(Instance::new_raw(instance.def_id(), instance.args));
+            }
             sym::breakpoint => {
                 unimplemented!();
             }

--- a/tests/run/zero_sized_mem.rs
+++ b/tests/run/zero_sized_mem.rs
@@ -1,0 +1,28 @@
+// Compiler:
+//
+// Run-time:
+//   status: 0
+
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+#![no_main]
+
+extern crate mini_core;
+use mini_core::*;
+
+#[inline(never)]
+unsafe fn zero_sized_mem_ops(count: usize) {
+    let src = 0usize as *const ();
+    let dst = 0usize as *mut ();
+
+    intrinsics::copy_nonoverlapping(src, dst, count);
+    intrinsics::copy(src, dst, count);
+    intrinsics::write_bytes(dst, 0xab, count);
+}
+
+#[no_mangle]
+extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+    unsafe { zero_sized_mem_ops(1) };
+    0
+}


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#516.

This avoids lowering zero-sized `copy`, `copy_nonoverlapping`, and `write_bytes` intrinsics to GCC memory builtins. For zero-sized element types, the operation has no bytes to touch, so the backend can return before the fallback lowering emits `memcpy`, `memmove`, or `memset`.

A small run test covers the three zero-sized memory intrinsic paths using `()` pointers.

Tested with:

- `git diff --check`
- `cargo fmt --check`
- `./y.sh test --mini-tests`
- `cargo test -p rustc_codegen_gcc --test lang_tests zero_sized_mem -- --nocapture`
