### PR TITLE
builder: Emit a plain jump for a switch with no cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
       run: |
         ./y.sh build --sysroot
         ./y.sh test --cargo-tests
+        CARGO_TEST_FLAGS="-Zmir-preserve-ub" ./y.sh test --cargo-tests -- mir_preserve_ub_empty_switch
 
     - name: Run y.sh cargo build
       run: |

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -570,6 +570,18 @@ impl<'a, 'gcc, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'gcc, 'tcx> {
         default_block: Block<'gcc>,
         cases: impl ExactSizeIterator<Item = (u128, Block<'gcc>)>,
     ) {
+        // A switch with no cases is equivalent to an unconditional jump to the
+        // default block. Such a `SwitchInt` (one with only an `otherwise` target)
+        // is normally simplified into a `goto`, but `-Z mir-preserve-ub` keeps it,
+        // so it can reach here with e.g. the `bool` discriminant produced by a
+        // range-pattern comparison. `gcc_jit_block_end_with_switch` rejects a
+        // discriminant that is not of integer type, so emit a plain jump instead
+        // of a (pointless) switch.
+        if cases.len() == 0 {
+            self.block.end_with_jump(self.location, default_block);
+            return;
+        }
+
         let mut gcc_cases = vec![];
         let typ = self.val_ty(value);
         // FIXME(FractalFir): This is a workaround for a libgccjit limitation.

--- a/tests/lang_tests.rs
+++ b/tests/lang_tests.rs
@@ -172,6 +172,16 @@ fn build_test_runner(
                 }
             }
 
+            // Extra flags passed at run time (as opposed to the compile-time
+            // `TEST_FLAGS`). This lets a single test opt into flags like
+            // `-Zmir-preserve-ub` via an `ignore-if` directive that checks
+            // whether `CARGO_TEST_FLAGS` is set.
+            if let Ok(flags) = std::env::var("CARGO_TEST_FLAGS") {
+                for flag in flags.split_whitespace() {
+                    compiler_args.push(flag.into());
+                }
+            }
+
             if build_mode.is_debug() {
                 compiler_args
                     .extend_from_slice(&["-C".to_string(), "llvm-args=sanitize-undefined".into()]);

--- a/tests/run/mir_preserve_ub_empty_switch.rs
+++ b/tests/run/mir_preserve_ub_empty_switch.rs
@@ -1,0 +1,35 @@
+// ignore-if: test -z "$CARGO_TEST_FLAGS"
+// Compiler:
+//
+// Run-time:
+//   status: 0
+
+// Regression test for https://github.com/rust-lang/rustc_codegen_gcc/issues/881
+//
+// This needs `-Zmir-preserve-ub`, so it is skipped unless that flag is passed
+// through `CARGO_TEST_FLAGS` (see the `ignore-if` directive above). Run it with:
+//   CARGO_TEST_FLAGS="-Zmir-preserve-ub" ./y.sh test --cargo-tests -- mir_preserve_ub_empty_switch
+
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+#![no_main]
+
+extern crate mini_core;
+use intrinsics::black_box;
+use mini_core::*;
+
+#[no_mangle]
+extern "C" fn main(argc: i32, _argv: *const *const u8) -> i32 {
+    // With `-Zmir-preserve-ub`, the range pattern below is lowered to a pair of
+    // comparisons and the second one becomes a `SwitchInt` with no cases (only
+    // an `otherwise` target) whose discriminant is the `bool` comparison
+    // result. `gcc_jit_block_end_with_switch` rejects a non-integer
+    // discriminant, so the backend must emit a plain jump for it instead.
+    let value = black_box(argc);
+    match value {
+        0..=9 => (),
+        _ => (),
+    }
+    0
+}


### PR DESCRIPTION
Closes rust-lang/rustc_codegen_gcc#881

A range-pattern match compiled with `-Zmir-preserve-ub` can leave a `SwitchInt` whose only target is `otherwise`. That reaches the backend as a switch with an empty case list, and in the reproducer the discriminant is the `bool` result of the range comparison. `gcc_jit_block_end_with_switch` only accepts an integer discriminant, so it errors out and leaves the block unterminated.

A switch with no cases always goes to the default block, so emit a plain jump in that case rather than building a degenerate switch. This is also what `codegen_ssa` already relies on for the LLVM backend, which tolerates the empty switch.

### Verification

Built the backend locally and ran the exact reproducer from the issue with `-Zmir-preserve-ub -Clink-dead-code=true`:

- Without this change, it reproduces the reported error verbatim:

  ```
  libgccjit.so: error: : gcc_jit_block_end_with_switch: expr: (...)53 <= (...)57 (type: bool) is not of integer type
  libgccjit.so: error: : unterminated block in ..._main: bb1
  ```

- With this change, it compiles cleanly and the resulting binary runs (exit 0).

The MIR confirms the shape. `bb0` holds `switchInt(_2: bool) -> [0: bb2, otherwise: bb1]`, which has a single case and is lowered to a conditional branch by `codegen_ssa`, so it never reaches here. `bb1` holds `switchInt(_3: bool) -> bb2`, a switch with zero cases, which is the one that hit the empty-case path.

No in-tree regression test, since the `lang_tester` harness has no per-file compile-flags and the bug needs `-Zmir-preserve-ub`. Happy to add one if there's a preferred spot.
