### PR TITLE
asm: Emit an error for asm goto with output operands

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -18,7 +18,7 @@ use rustc_target::asm::*;
 use crate::builder::Builder;
 use crate::callee::get_fn;
 use crate::context::CodegenCx;
-use crate::errors::{NulBytesInAsm, UnwindingInlineAsm};
+use crate::errors::{AsmGotoWithOutputs, NulBytesInAsm, UnwindingInlineAsm};
 use crate::type_of::LayoutGccExt;
 
 // Rust asm! and GCC Extended Asm semantics differ substantially.
@@ -542,6 +542,15 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
         if template_str.contains('\0') {
             let err_sp = span.first().copied().unwrap_or(DUMMY_SP);
             self.sess().dcx().emit_err(NulBytesInAsm { span: err_sp });
+            return;
+        }
+
+        // GCC's `asm goto` cannot have output operands (libgccjit rejects them with
+        // "cannot add output operand to asm goto"). Emit a clean error instead of
+        // letting libgccjit abort with an internal error.
+        if dest.is_some() && !outputs.is_empty() {
+            let err_sp = span.first().copied().unwrap_or(DUMMY_SP);
+            self.sess().dcx().emit_err(AsmGotoWithOutputs { span: err_sp });
             return;
         }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -30,3 +30,10 @@ pub(crate) struct NulBytesInAsm {
     #[primary_span]
     pub span: Span,
 }
+
+#[derive(Diagnostic)]
+#[diag("GCC backend does not support `asm goto` with output operands")]
+pub(crate) struct AsmGotoWithOutputs {
+    #[primary_span]
+    pub span: Span,
+}

--- a/tests/compile/asm_goto_with_outputs.rs
+++ b/tests/compile/asm_goto_with_outputs.rs
@@ -1,0 +1,25 @@
+// Compiler:
+//   status: error
+//   stderr:
+//     error: GCC backend does not support `asm goto` with output operands
+//     ...
+
+// Test that an `asm goto` with output operands emits a clean error instead of an
+// ICE: libgccjit rejects output operands on an `asm goto` (issue #835).
+
+#![feature(asm_goto_with_outputs)]
+
+use std::arch::asm;
+
+fn main() {
+    let mut a: i32 = 0;
+    unsafe {
+        asm!(
+            "jmp {op}",
+            inout("eax") a,
+            op = label { a = 7; },
+            options(nostack, nomem),
+        );
+    }
+    let _ = a;
+}

--- a/tests/lang_tests.rs
+++ b/tests/lang_tests.rs
@@ -201,7 +201,13 @@ fn compile_tests(tempdir: PathBuf, current_dir: String) {
         "lang compile",
         "tests/compile",
         TestMode::Compile,
-        &["simd-ffi.rs", "asm_nul_byte.rs", "global_asm_nul_byte.rs", "naked_asm_nul_byte.rs"],
+        &[
+            "simd-ffi.rs",
+            "asm_nul_byte.rs",
+            "asm_goto_with_outputs.rs",
+            "global_asm_nul_byte.rs",
+            "naked_asm_nul_byte.rs",
+        ],
     );
 }
 


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#835

An `asm goto` with output operands aborted codegen with an internal error. libgccjit won't let you attach output operands to an `asm goto` through its API, even though GCC's C frontend has allowed it since GCC 11, so the build died with "cannot add output operand to asm goto" and then a second complaint about adding to an already-terminated block.

The inline asm codegen now catches that combination before handing anything to libgccjit and emits a regular diagnostic instead, the same way the backend already turns away other unsupported asm. Comes with a compile-fail test.