### PR TITLE
Lower x86-interrupt byval first argument as pointer

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -159,7 +159,10 @@ impl<'gcc, 'tcx> FnAbiGccExt<'gcc, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
         #[cfg(not(feature = "master"))]
         let apply_attrs = |ty: Type<'gcc>, _attrs: &ArgAttributes, _arg_index: usize| ty;
 
-        for arg in self.args.iter() {
+        for (source_arg_index, arg) in self.args.iter().enumerate() {
+            #[cfg(not(feature = "master"))]
+            let _ = source_arg_index;
+
             let arg_ty = match arg.mode {
                 PassMode::Ignore => continue,
                 PassMode::Pair(a, b) => {
@@ -185,9 +188,31 @@ impl<'gcc, 'tcx> FnAbiGccExt<'gcc, 'tcx> for FnAbi<'tcx, Ty<'tcx>> {
                     apply_attrs(ty, &cast.attrs, argument_tys.len())
                 }
                 PassMode::Indirect { attrs: _, meta_attrs: None, on_stack: true } => {
-                    // This is a "byval" argument, so we don't apply the `restrict` attribute on it.
-                    on_stack_param_indices.insert(argument_tys.len());
-                    arg.layout.gcc_type(cx)
+                    let x86_interrupt_first_arg = {
+                        #[cfg(feature = "master")]
+                        {
+                            source_arg_index == 0
+                                && matches!(self.conv, CanonAbi::Interrupt(InterruptKind::X86))
+                        }
+                        #[cfg(not(feature = "master"))]
+                        {
+                            false
+                        }
+                    };
+
+                    if x86_interrupt_first_arg {
+                        // Rust lowers the first `x86-interrupt` argument as a byval stack slot.
+                        // LLVM represents that as a pointer parameter with `byval`; GCC's
+                        // interrupt attribute likewise requires a pointer-shaped first parameter.
+                        // Do not add this parameter to `on_stack_param_indices`: that set is only
+                        // needed when GCC represents a byval argument as a value parameter, while
+                        // this parameter is already pointer-shaped.
+                        cx.type_ptr_to(arg.layout.gcc_type(cx))
+                    } else {
+                        // This is a "byval" argument, so we don't apply the `restrict` attribute on it.
+                        on_stack_param_indices.insert(argument_tys.len());
+                        arg.layout.gcc_type(cx)
+                    }
                 }
                 PassMode::Direct(attrs) => {
                     apply_attrs(arg.layout.immediate_gcc_type(cx), &attrs, argument_tys.len())

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -2,6 +2,8 @@
 use gccjit::FnAttribute;
 use gccjit::Function;
 #[cfg(feature = "master")]
+use rustc_abi::{CanonAbi, InterruptKind};
+#[cfg(feature = "master")]
 use rustc_hir::attrs::InlineAttr;
 use rustc_hir::attrs::InstructionSetAttr;
 #[cfg(feature = "master")]
@@ -9,6 +11,7 @@ use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
 #[cfg(feature = "master")]
 use rustc_middle::mir::TerminatorKind;
 use rustc_middle::ty;
+use rustc_target::callconv::FnAbi;
 #[cfg(feature = "master")]
 use rustc_target::spec::Arch;
 
@@ -82,12 +85,23 @@ fn inline_attr<'gcc, 'tcx>(
     }
 }
 
+#[cfg(feature = "master")]
+fn is_x86_interrupt<'tcx>(fn_abi: Option<&FnAbi<'tcx, ty::Ty<'tcx>>>) -> bool {
+    matches!(
+        fn_abi,
+        Some(fn_abi) if matches!(fn_abi.conv, CanonAbi::Interrupt(InterruptKind::X86))
+    )
+}
+
 /// Composite function which sets GCC attributes for function depending on its AST (`#[attribute]`)
 /// attributes.
 pub fn from_fn_attrs<'gcc, 'tcx>(
     cx: &CodegenCx<'gcc, 'tcx>,
     #[cfg_attr(not(feature = "master"), expect(unused_variables))] func: Function<'gcc>,
     instance: ty::Instance<'tcx>,
+    #[cfg_attr(not(feature = "master"), expect(unused_variables))] fn_abi: Option<
+        &FnAbi<'tcx, ty::Ty<'tcx>>,
+    >,
 ) {
     let codegen_fn_attrs = cx.tcx.codegen_instance_attrs(instance.def);
 
@@ -120,6 +134,11 @@ pub fn from_fn_attrs<'gcc, 'tcx>(
         }
     }
 
+    #[cfg(feature = "master")]
+    let x86_interrupt = is_x86_interrupt(fn_abi);
+    #[cfg(not(feature = "master"))]
+    let x86_interrupt = false;
+
     let mut function_features = codegen_fn_attrs
         .target_features
         .iter()
@@ -135,6 +154,13 @@ pub fn from_fn_attrs<'gcc, 'tcx>(
     // Check if GCC requires the same.
     let mut global_features = cx.tcx.global_backend_features(()).iter().map(|s| s.as_str());
     function_features.extend(&mut global_features);
+    if x86_interrupt {
+        // GCC does not preserve SSE, MMX, or x87 state in interrupt handlers and rejects
+        // them whenever those instruction sets are enabled, even if the handler does not
+        // emit such instructions. Restrict the function to general registers so the
+        // interrupt attribute works with the default x86_64 target features.
+        function_features.push("general-regs-only");
+    }
     let target_features = function_features
         .iter()
         .filter_map(|feature| {

--- a/src/callee.rs
+++ b/src/callee.rs
@@ -70,7 +70,7 @@ pub fn get_fn<'gcc, 'tcx>(cx: &CodegenCx<'gcc, 'tcx>, instance: Instance<'tcx>) 
         cx.linkage.set(FunctionType::Extern);
         let func = cx.declare_fn(sym, fn_abi);
 
-        attributes::from_fn_attrs(cx, func, instance);
+        attributes::from_fn_attrs(cx, func, instance, Some(fn_abi));
 
         #[cfg(feature = "master")]
         {

--- a/src/declare.rs
+++ b/src/declare.rs
@@ -6,7 +6,7 @@ use rustc_middle::ty::Ty;
 use rustc_span::Symbol;
 use rustc_target::callconv::FnAbi;
 
-use crate::abi::{FnAbiGcc, FnAbiGccExt};
+use crate::abi::FnAbiGccExt;
 use crate::context::CodegenCx;
 
 impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
@@ -110,22 +110,22 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
     }
 
     pub fn declare_fn(&self, name: &str, fn_abi: &FnAbi<'tcx, Ty<'tcx>>) -> Function<'gcc> {
-        let FnAbiGcc {
-            return_type,
-            arguments_type,
-            is_c_variadic,
-            on_stack_param_indices,
-            #[cfg(feature = "master")]
-            fn_attributes,
-        } = fn_abi.gcc_type(self);
+        let fn_abi_gcc = fn_abi.gcc_type(self);
         #[cfg(feature = "master")]
         let conv = fn_abi.gcc_cconv(self);
         #[cfg(not(feature = "master"))]
         let conv = None;
-        let func = declare_raw_fn(self, name, conv, return_type, &arguments_type, is_c_variadic);
-        self.on_stack_function_params.borrow_mut().insert(func, on_stack_param_indices);
+        let func = declare_raw_fn(
+            self,
+            name,
+            conv,
+            fn_abi_gcc.return_type,
+            &fn_abi_gcc.arguments_type,
+            fn_abi_gcc.is_c_variadic,
+        );
+        self.on_stack_function_params.borrow_mut().insert(func, fn_abi_gcc.on_stack_param_indices);
         #[cfg(feature = "master")]
-        for fn_attr in fn_attributes {
+        for fn_attr in fn_abi_gcc.fn_attributes {
             func.add_attribute(fn_attr);
         }
         func

--- a/src/intrinsic/mod.rs
+++ b/src/intrinsic/mod.rs
@@ -588,7 +588,7 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tc
 
                 self.on_stack_function_params.borrow_mut().insert(func, FxHashSet::default());
 
-                crate::attributes::from_fn_attrs(self, func, instance);
+                crate::attributes::from_fn_attrs(self, func, instance, None);
 
                 func
             };

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -151,7 +151,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         self.linkage.set(base::linkage_to_gcc(linkage));
         let fn_decl = self.declare_fn(symbol_name, fn_abi);
 
-        attributes::from_fn_attrs(self, fn_decl, instance);
+        attributes::from_fn_attrs(self, fn_decl, instance, Some(fn_abi));
 
         // If we're compiling the compiler-builtins crate, e.g., the equivalent of
         // compiler-rt, then we want to implicitly compile everything with hidden

--- a/tests/compile/x86_interrupt_first_arg_byval.rs
+++ b/tests/compile/x86_interrupt_first_arg_byval.rs
@@ -1,0 +1,16 @@
+// Compiler:
+
+// Test that `x86-interrupt` functions whose first argument is passed by value
+// emit pointer-shaped GCC parameters and compile with interrupt-safe target features.
+
+#![feature(abi_x86_interrupt)]
+#![crate_type = "lib"]
+
+#[repr(C)]
+pub struct Frame {
+    ip: u64,
+}
+
+pub extern "x86-interrupt" fn scalar(_a: i64) {}
+
+pub extern "x86-interrupt" fn aggregate(_frame: Frame) {}

--- a/tests/lang_tests.rs
+++ b/tests/lang_tests.rs
@@ -211,7 +211,13 @@ fn compile_tests(tempdir: PathBuf, current_dir: String) {
         "lang compile",
         "tests/compile",
         TestMode::Compile,
-        &["simd-ffi.rs", "asm_nul_byte.rs", "global_asm_nul_byte.rs", "naked_asm_nul_byte.rs"],
+        &[
+            "simd-ffi.rs",
+            "asm_nul_byte.rs",
+            "global_asm_nul_byte.rs",
+            "naked_asm_nul_byte.rs",
+            "x86_interrupt_first_arg_byval.rs",
+        ],
     );
 }
 


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#833

An `extern "x86-interrupt"` function can have a by-value first Rust argument, such as `i64` or a by-value struct. rustc's LLVM backend lowers that first byval stack argument to a pointer-shaped backend parameter for `x86_intrcc`.

GCC's `interrupt` attribute expects the same pointer-shaped first parameter. Without that lowering, libgccjit reports `interrupt service routine should have a pointer as the first argument` and does not write an object file, which then shows up as a confusing follow-up archive/object error.

Mirror rustc's lowering in the GCC backend for the first `x86-interrupt` byval argument, while keeping the interrupt attribute. This avoids the libgccjit abort without rejecting a Rust signature that rustc accepts.

The regression test covers scalar and by-value struct first arguments.
