### PR TITLE
Allow to specify the channel for the `rustc` command

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -136,18 +136,20 @@ $ ./y.sh cargo build --manifest-path tests/hello-world/Cargo.toml
 ### Cargo
 
 ```bash
-$ CHANNEL="release" $CG_GCCJIT_DIR/y.sh cargo run
+$ CHANNEL=release $CG_GCCJIT_DIR/y.sh cargo run
 ```
 
-If you compiled cg_gccjit in debug mode (aka you didn't pass `--release` to `./y.sh test`) you should use `CHANNEL="debug"` instead or omit `CHANNEL="release"` completely.
+If you compiled `cg_gcc` in debug mode (aka you didn't pass `--release` to `./y.sh build`) you should use `CHANNEL=debug` instead or omit `CHANNEL=release` completely.
 
 ### Rustc
 
 If you want to run `rustc` directly, you can do so with:
 
 ```bash
-$ ./y.sh rustc my_crate.rs
+$ CHANNEL=release ./y.sh rustc my_crate.rs
 ```
+
+If you compiled `cg_gcc` in debug mode (aka you didn't pass `--release` to `./y.sh build`) you should use `CHANNEL=debug` instead or omit `CHANNEL=release` completely.
 
 You can do the same manually (although we don't recommend it):
 

--- a/build_system/src/build.rs
+++ b/build_system/src/build.rs
@@ -227,7 +227,7 @@ fn build_codegen(args: &mut BuildArg) -> Result<(), String> {
     }
     run_command_with_output_and_env(&command, None, Some(&env))?;
 
-    args.config_info.setup(&mut env, false)?;
+    args.config_info.setup(&mut env, false, true)?;
 
     // We voluntarily ignore the error.
     let _ = fs::remove_dir_all("target/out");

--- a/build_system/src/config.rs
+++ b/build_system/src/config.rs
@@ -314,6 +314,7 @@ impl ConfigInfo {
         &mut self,
         env: &mut HashMap<String, String>,
         use_system_gcc: bool,
+        generate_out_dir: bool,
     ) -> Result<(), String> {
         env.insert("CARGO_INCREMENTAL".to_string(), "0".to_string());
 
@@ -444,12 +445,12 @@ impl ConfigInfo {
 
         self.rustc_command = vec![rustc];
         self.rustc_command.extend_from_slice(&rustflags);
-        self.rustc_command.extend_from_slice(&[
-            "-L".to_string(),
-            format!("crate={}", self.cargo_target_dir),
-            "--out-dir".to_string(),
-            self.cargo_target_dir.clone(),
-        ]);
+        self.rustc_command
+            .extend_from_slice(&["-L".to_string(), format!("crate={}", self.cargo_target_dir)]);
+        if generate_out_dir {
+            self.rustc_command
+                .extend_from_slice(&["--out-dir".to_string(), self.cargo_target_dir.clone()]);
+        }
 
         if !env.contains_key("RUSTC_LOG") {
             env.insert("RUSTC_LOG".to_string(), "warn".to_string());

--- a/build_system/src/rust_tools.rs
+++ b/build_system/src/rust_tools.rs
@@ -72,7 +72,7 @@ impl RustcTools {
 
         let mut env: HashMap<String, String> = std::env::vars().collect();
         let mut config = ConfigInfo::default();
-        config.setup(&mut env, false)?;
+        config.setup(&mut env, false, false)?;
         let toolchain = get_toolchain()?;
 
         let toolchain_version = rustc_toolchain_version_info(&toolchain)?;

--- a/build_system/src/test.rs
+++ b/build_system/src/test.rs
@@ -1358,7 +1358,7 @@ pub fn run() -> Result<(), String> {
         return Ok(());
     }
 
-    args.config_info.setup(&mut env, args.use_system_gcc)?;
+    args.config_info.setup(&mut env, args.use_system_gcc, true)?;
 
     if args.runners.is_empty() {
         run_all(&env, &args)?;


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#902.