### PR TITLE
Add support for aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,18 +56,18 @@ dependencies = [
 
 [[package]]
 name = "gccjit"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796be22e4854830de9e785ddbd814b275a80fe6a975598be355c239e5b4eabe1"
+checksum = "5bd96d5f5f1752c2f6ff639d19d51f2b64c6169981606f5066808685f75f58b4"
 dependencies = [
  "gccjit_sys",
 ]
 
 [[package]]
 name = "gccjit_sys"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db558fc13a541c478ef791d2a88cdb276a9373f46fb2e8aa30734d19037ffa6"
+checksum = "7a34e8df2602945338835eade9ef69a057203197ad32ec512a9c763b96dafab5"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ default = ["master"]
 [dependencies]
 object = { version = "0.37.0", default-features = false, features = ["std", "read"] }
 tempfile = "3.20"
-gccjit = { version = "3.5.0", features = ["dlopen"] }
+gccjit = { version = "3.6.0", features = ["dlopen"] }
 #gccjit = { git = "https://github.com/rust-lang/gccjit.rs", branch = "error-dlopen", features = ["dlopen"] }
 
 # Local copy.

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -1,11 +1,16 @@
 #[cfg(feature = "master")]
-use gccjit::{FnAttribute, VarAttribute, LValue};
+use std::borrow::Cow;
+
+#[cfg(feature = "master")]
+use gccjit::{FnAttribute, Function, LValue, ToRValue, VarAttribute};
 use rustc_codegen_ssa::traits::PreDefineCodegenMethods;
 use rustc_hir::attrs::Linkage;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::bug;
 use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
+#[cfg(feature = "master")]
+use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
 use rustc_middle::mono::Visibility;
 use rustc_middle::ty::layout::{FnAbiOf, HasTypingEnv, LayoutOf};
 use rustc_middle::ty::{self, Instance, TypeVisitableExt};
@@ -44,6 +49,7 @@ impl<'gcc, 'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         let global = create_global(self, global_name, visibility);
 
         let attrs = self.tcx.codegen_instance_attrs(instance.def);
+        #[cfg(feature = "master")]
         self.add_static_aliases(&attrs.foreign_item_symbol_aliases, global_name, &create_global);
 
         self.instances.borrow_mut().insert(instance, global);
@@ -58,38 +64,28 @@ impl<'gcc, 'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
     ) {
         assert!(!instance.args.has_infer());
 
-        let fn_abi = self.fn_abi_of_instance(instance, ty::List::empty());
-        self.linkage.set(base::linkage_to_gcc(linkage));
-        let decl = self.declare_fn(symbol_name, fn_abi);
-        //let attrs = self.tcx.codegen_instance_attrs(instance.def);
+        let attrs = self.tcx.codegen_instance_attrs(instance.def);
 
-        attributes::from_fn_attrs(self, decl, instance);
+        let decl =
+            self.predefine_without_aliases(instance, &attrs, linkage, visibility, symbol_name);
 
-        // If we're compiling the compiler-builtins crate, e.g., the equivalent of
-        // compiler-rt, then we want to implicitly compile everything with hidden
-        // visibility as we're going to link this object all over the place but
-        // don't want the symbols to get exported.
-        if linkage != Linkage::Internal && self.tcx.is_compiler_builtins(LOCAL_CRATE) {
-            #[cfg(feature = "master")]
-            decl.add_attribute(FnAttribute::Visibility(gccjit::Visibility::Hidden));
-        } else if visibility != Visibility::Default {
-            #[cfg(feature = "master")]
-            decl.add_attribute(FnAttribute::Visibility(base::visibility_to_gcc(visibility)));
-        }
-
-        // FIXME(antoyo): call set_link_section() to allow initializing argc/argv.
-        // FIXME(antoyo): set unique comdat.
-        // FIXME(antoyo): use inline attribute from there in linkage.set() above.
+        #[cfg(feature = "master")]
+        self.add_function_aliases(instance, decl, &attrs, &attrs.foreign_item_symbol_aliases);
 
         self.functions.borrow_mut().insert(symbol_name.to_string(), decl);
         self.function_instances.borrow_mut().insert(instance, decl);
     }
 }
 
-#[cfg(feature = "master")]
 impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
-    fn add_static_aliases<F>(&self, aliases: &[(DefId, Linkage, Visibility)], aliasee: &str, create_global: &F)
-        where F: Fn(&CodegenCx<'gcc, 'tcx>, &str, Visibility) -> LValue<'gcc>
+    #[cfg(feature = "master")]
+    fn add_static_aliases<F>(
+        &self,
+        aliases: &[(DefId, Linkage, Visibility)],
+        aliasee: &str,
+        create_global: &F,
+    ) where
+        F: Fn(&CodegenCx<'gcc, 'tcx>, &str, Visibility) -> LValue<'gcc>,
     {
         for (alias, _linkage, visibility) in aliases {
             let instance = Instance::mono(self.tcx, *alias);
@@ -106,5 +102,80 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             // which would result in incorrect codegen
             assert!(prev_entry.is_none(), "An instance was already present for {instance:?}");
         }
+    }
+
+    #[cfg(feature = "master")]
+    fn add_function_aliases(
+        &self,
+        aliasee_instance: Instance<'tcx>,
+        aliasee: Function<'gcc>,
+        attrs: &Cow<'_, CodegenFnAttrs>,
+        aliases: &[(DefId, Linkage, Visibility)],
+    ) {
+        for (alias, linkage, visibility) in aliases {
+            let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, *alias));
+
+            // predefine another copy of the original instance
+            // with a new symbol name
+            let alias_fn_decl = self.predefine_without_aliases(
+                aliasee_instance,
+                attrs,
+                *linkage,
+                *visibility,
+                symbol_name.name,
+            );
+
+            let block = alias_fn_decl.new_block("start");
+            let nb_params = alias_fn_decl.get_param_count();
+            let mut args = Vec::with_capacity(nb_params);
+            for idx in 0..nb_params {
+                args.push(alias_fn_decl.get_param(idx as _).to_rvalue());
+            }
+
+            let void_type = self.context.new_type::<()>();
+            let call = self.context.new_call(None, aliasee, &args);
+            if alias_fn_decl.get_return_type() == void_type {
+                block.add_eval(None, call);
+                block.end_with_void_return(None);
+            } else {
+                block.end_with_return(None, call);
+            }
+        }
+    }
+
+    fn predefine_without_aliases(
+        &self,
+        instance: Instance<'tcx>,
+        _attrs: &Cow<'_, CodegenFnAttrs>,
+        linkage: Linkage,
+        visibility: Visibility,
+        symbol_name: &str,
+    ) -> Function<'gcc> {
+        let fn_abi = self.fn_abi_of_instance(instance, ty::List::empty());
+        self.linkage.set(base::linkage_to_gcc(linkage));
+        let fn_decl = self.declare_fn(symbol_name, fn_abi);
+
+        attributes::from_fn_attrs(self, fn_decl, instance);
+
+        // If we're compiling the compiler-builtins crate, e.g., the equivalent of
+        // compiler-rt, then we want to implicitly compile everything with hidden
+        // visibility as we're going to link this object all over the place but
+        // don't want the symbols to get exported.
+        if linkage != Linkage::Internal && self.tcx.is_compiler_builtins(LOCAL_CRATE) {
+            #[cfg(feature = "master")]
+            fn_decl.add_attribute(FnAttribute::Visibility(gccjit::Visibility::Hidden));
+        } else if visibility != Visibility::Default {
+            #[cfg(feature = "master")]
+            fn_decl.add_attribute(FnAttribute::Visibility(base::visibility_to_gcc(visibility)));
+        }
+
+        // FIXME(GuillaumeGomez): Add support for link section for `Function`.
+        // fn_decl.set_link_section(&attrs.link_section);
+
+        // FIXME(antoyo): set unique comdat.
+        // FIXME(antoyo): use inline attribute from there in linkage.set() above.
+        // FIXME: Should we handle dso?
+
+        fn_decl
     }
 }

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "master")]
-use gccjit::{FnAttribute, VarAttribute};
+use gccjit::{FnAttribute, VarAttribute, LValue};
 use rustc_codegen_ssa::traits::PreDefineCodegenMethods;
 use rustc_hir::attrs::Linkage;
 use rustc_hir::def::DefKind;
@@ -21,7 +21,7 @@ impl<'gcc, 'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         def_id: DefId,
         _linkage: Linkage,
         visibility: Visibility,
-        symbol_name: &str,
+        global_name: &str,
     ) {
         let attrs = self.tcx.codegen_fn_attrs(def_id);
         let instance = Instance::mono(self.tcx, def_id);
@@ -33,11 +33,19 @@ impl<'gcc, 'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
         let gcc_type = self.layout_of(ty).gcc_type(self);
 
         let is_tls = attrs.flags.contains(CodegenFnAttrFlags::THREAD_LOCAL);
-        let global = self.define_global(symbol_name, gcc_type, is_tls, attrs.link_section);
-        #[cfg(feature = "master")]
-        global.add_attribute(VarAttribute::Visibility(base::visibility_to_gcc(visibility)));
 
-        // FIXME(antoyo): set linkage.
+        let create_global = |this: &CodegenCx<'gcc, 'tcx>, name: &str, visibility: Visibility| {
+            let global = this.define_global(name, gcc_type, is_tls, attrs.link_section);
+            #[cfg(feature = "master")]
+            global.add_attribute(VarAttribute::Visibility(base::visibility_to_gcc(visibility)));
+            // FIXME(antoyo): set linkage.
+            global
+        };
+        let global = create_global(self, global_name, visibility);
+
+        let attrs = self.tcx.codegen_instance_attrs(instance.def);
+        self.add_static_aliases(&attrs.foreign_item_symbol_aliases, global_name, &create_global);
+
         self.instances.borrow_mut().insert(instance, global);
     }
 
@@ -75,5 +83,28 @@ impl<'gcc, 'tcx> PreDefineCodegenMethods<'tcx> for CodegenCx<'gcc, 'tcx> {
 
         self.functions.borrow_mut().insert(symbol_name.to_string(), decl);
         self.function_instances.borrow_mut().insert(instance, decl);
+    }
+}
+
+#[cfg(feature = "master")]
+impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
+    fn add_static_aliases<F>(&self, aliases: &[(DefId, Linkage, Visibility)], aliasee: &str, create_global: &F)
+        where F: Fn(&CodegenCx<'gcc, 'tcx>, &str, Visibility) -> LValue<'gcc>
+    {
+        for (alias, _linkage, visibility) in aliases {
+            let instance = Instance::mono(self.tcx, *alias);
+            let symbol_name = self.tcx.symbol_name(instance);
+
+            let alias = create_global(self, symbol_name.name, *visibility);
+            alias.add_attribute(VarAttribute::Alias(aliasee));
+
+            // Add the alias name to the set of cached items, so there is no duplicate
+            // instance added to it during the normal `external static` codegen
+            let prev_entry = self.instances.borrow_mut().insert(instance, alias);
+
+            // If there already was a previous entry, then `add_static_aliases` was called multiple times for the same `alias`
+            // which would result in incorrect codegen
+            assert!(prev_entry.is_none(), "An instance was already present for {instance:?}");
+        }
     }
 }

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -1,16 +1,12 @@
+use gccjit::Function;
 #[cfg(feature = "master")]
-use std::borrow::Cow;
-
-#[cfg(feature = "master")]
-use gccjit::{FnAttribute, Function, LValue, ToRValue, VarAttribute};
+use gccjit::{FnAttribute, LValue, ToRValue, VarAttribute};
 use rustc_codegen_ssa::traits::PreDefineCodegenMethods;
 use rustc_hir::attrs::Linkage;
 use rustc_hir::def::DefKind;
 use rustc_hir::def_id::{DefId, LOCAL_CRATE};
 use rustc_middle::bug;
-use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrFlags;
-#[cfg(feature = "master")]
-use rustc_middle::middle::codegen_fn_attrs::CodegenFnAttrs;
+use rustc_middle::middle::codegen_fn_attrs::{CodegenFnAttrFlags, CodegenFnAttrs};
 use rustc_middle::mono::Visibility;
 use rustc_middle::ty::layout::{FnAbiOf, HasTypingEnv, LayoutOf};
 use rustc_middle::ty::{self, Instance, TypeVisitableExt};
@@ -87,11 +83,11 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
     ) where
         F: Fn(&CodegenCx<'gcc, 'tcx>, &str, Visibility) -> LValue<'gcc>,
     {
-        for (alias, _linkage, visibility) in aliases {
-            let instance = Instance::mono(self.tcx, *alias);
+        for &(alias, _linkage, visibility) in aliases {
+            let instance = Instance::mono(self.tcx, alias);
             let symbol_name = self.tcx.symbol_name(instance);
 
-            let alias = create_global(self, symbol_name.name, *visibility);
+            let alias = create_global(self, symbol_name.name, visibility);
             alias.add_attribute(VarAttribute::Alias(aliasee));
 
             // Add the alias name to the set of cached items, so there is no duplicate
@@ -109,19 +105,19 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
         &self,
         aliasee_instance: Instance<'tcx>,
         aliasee: Function<'gcc>,
-        attrs: &Cow<'_, CodegenFnAttrs>,
+        attrs: &CodegenFnAttrs,
         aliases: &[(DefId, Linkage, Visibility)],
     ) {
-        for (alias, linkage, visibility) in aliases {
-            let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, *alias));
+        for &(alias, linkage, visibility) in aliases {
+            let symbol_name = self.tcx.symbol_name(Instance::mono(self.tcx, alias));
 
             // predefine another copy of the original instance
             // with a new symbol name
             let alias_fn_decl = self.predefine_without_aliases(
                 aliasee_instance,
                 attrs,
-                *linkage,
-                *visibility,
+                linkage,
+                visibility,
                 symbol_name.name,
             );
 
@@ -146,7 +142,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
     fn predefine_without_aliases(
         &self,
         instance: Instance<'tcx>,
-        _attrs: &Cow<'_, CodegenFnAttrs>,
+        _attrs: &CodegenFnAttrs,
         linkage: Linkage,
         visibility: Visibility,
         symbol_name: &str,

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -78,7 +78,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
     fn add_static_aliases<F>(
         &self,
         aliases: &[(DefId, Linkage, Visibility)],
-        aliasee: &str,
+        aliased: &str,
         create_global: &F,
     ) where
         F: Fn(&CodegenCx<'gcc, 'tcx>, &str, Visibility) -> LValue<'gcc>,
@@ -88,7 +88,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             let symbol_name = self.tcx.symbol_name(instance);
 
             let alias = create_global(self, symbol_name.name, visibility);
-            alias.add_attribute(VarAttribute::Alias(aliasee));
+            alias.add_attribute(VarAttribute::Alias(aliased));
 
             // Add the alias name to the set of cached items, so there is no duplicate
             // instance added to it during the normal `external static` codegen
@@ -103,8 +103,8 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
     #[cfg(feature = "master")]
     fn add_function_aliases(
         &self,
-        aliasee_instance: Instance<'tcx>,
-        aliasee: Function<'gcc>,
+        aliased_instance: Instance<'tcx>,
+        aliased: Function<'gcc>,
         attrs: &CodegenFnAttrs,
         aliases: &[(DefId, Linkage, Visibility)],
     ) {
@@ -114,7 +114,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             // predefine another copy of the original instance
             // with a new symbol name
             let alias_fn_decl = self.predefine_without_aliases(
-                aliasee_instance,
+                aliased_instance,
                 attrs,
                 linkage,
                 visibility,
@@ -129,7 +129,7 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             }
 
             let void_type = self.context.new_type::<()>();
-            let call = self.context.new_call(None, aliasee, &args);
+            let call = self.context.new_call(None, aliased, &args);
             if alias_fn_decl.get_return_type() == void_type {
                 block.add_eval(None, call);
                 block.end_with_void_return(None);

--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -80,21 +80,11 @@ tests/ui/thir-print/offset_of.rs
 tests/ui/iterators/rangefrom-overflow-debug.rs
 tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
 tests/ui/iterators/iter-filter-count-debug-check.rs
-tests/ui/eii/linking/codegen_single_crate.rs
-tests/ui/eii/linking/codegen_cross_crate.rs
-tests/ui/eii/default/local_crate.rs
-tests/ui/eii/duplicate/multiple_impls.rs
-tests/ui/eii/default/call_default.rs
-tests/ui/eii/linking/same-symbol.rs
-tests/ui/eii/privacy1.rs
 tests/ui/eii/default/call_impl.rs
-tests/ui/eii/linking/track_caller_cross_crate.rs
 tests/ui/asm/x86_64/global_asm_escape.rs
 tests/ui/lto/all-crates.rs
-tests/ui/eii/default/call_default_panics.rs
 tests/ui/traits/inheritance/self-in-supertype.rs
 tests/ui/fmt/fmt_debug/shallow.rs
-tests/ui/eii/eii_impl_with_contract.rs
 tests/ui/eii/static/cross_crate_decl.rs
 tests/ui/eii/static/cross_crate_def.rs
 tests/ui/eii/static/same_address.rs
@@ -132,4 +122,3 @@ tests/ui/drop/enum-destructor-on-unwind.rs
 tests/ui/drop/drop-trait-enum.rs
 tests/ui/drop/panic-during-slice-init.rs
 tests/ui/drop/terminate-in-initializer.rs
-tests/ui/eii/track_caller.rs


### PR DESCRIPTION
Now only 9 `tests/ui/eii` tests are failing out of 60. I think the remaining ones comes from the `link_section` that we don't support yet.

Considering most of the work is already done, I think it's worth merging this first step already. :)