### PR TITLE
gcc: locate codegen-backends via host_tuple()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,10 @@ impl CodegenBackend for GccCodegenBackend {
 
     fn init(&self, sess: &Session) {
         fn file_path(sysroot_path: &Path, sess: &Session) -> PathBuf {
-            let rustlib_path =
-                rustc_target::relative_target_rustlib_path(sysroot_path, &sess.host.llvm_target);
+            let rustlib_path = rustc_target::relative_target_rustlib_path(
+                sysroot_path,
+                rustc_session::config::host_tuple(),
+            );
             sysroot_path
                 .join(rustlib_path)
                 .join("codegen-backends")


### PR DESCRIPTION
`file_path` builds the `lib/rustlib/<host>/codegen-backends` path used to load the codegen backend. It passed `&sess.host.llvm_target`, but that is the host's LLVM target string, not its rustc target tuple.  The two can differ (e.g. `arm64-apple-macosx` vs `aarch64-apple-darwin`), so the lookup can miss the directory that actually holds the backend. Use `rustc_session::config::host_tuple()` instead.

This fixes an issue when building custom toolchains. In particular, I'm using the gcc backend to build a custom SH4 compiler. Without this patch, this command fails to find the backend:

```
$ BOOTSTRAP_SKIP_TARGET_SANITY=1 python3 x.py install library --target sh4-dreamcast-none-elf
```