### PR TITLE
Add support for section linking

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -160,13 +160,20 @@ impl<'gcc, 'tcx> StaticCodegenMethods for CodegenCx<'gcc, 'tcx> {
         }
 
         // Wasm statics with custom link sections get special treatment as they
-        // go into custom sections of the wasm executable.
-        if self.tcx.sess.target.is_like_wasm {
+        // go into custom sections of the wasm executable. The exception to this
+        // is the `.init_array` section which are treated specially by the wasm linker.
+        if self.tcx.sess.target.is_like_wasm
+            && attrs
+                .link_section
+                .map(|link_section| !link_section.as_str().starts_with(".init_array"))
+                .unwrap_or(true)
+        {
             if let Some(_section) = attrs.link_section {
                 unimplemented!();
             }
-        } else {
-            // FIXME(antoyo): set link section.
+        } else if let Some(_section) = attrs.link_section {
+            #[cfg(feature = "master")]
+            global.add_attribute(VarAttribute::Section(_section.as_str()));
         }
 
         if attrs.flags.contains(CodegenFnAttrFlags::USED_COMPILER) {

--- a/src/declare.rs
+++ b/src/declare.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "master")]
-use gccjit::{FnAttribute, ToRValue};
+use gccjit::{FnAttribute, ToRValue, VarAttribute};
 use gccjit::{Function, FunctionType, GlobalKind, LValue, RValue, Type};
 use rustc_codegen_ssa::traits::BaseTypeCodegenMethods;
 use rustc_middle::ty::Ty;
@@ -24,6 +24,9 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
                 global.set_tls_model(self.tls_model);
             }
             if let Some(link_section) = link_section {
+                #[cfg(feature = "master")]
+                global.add_attribute(VarAttribute::Section(link_section.as_str()));
+                #[cfg(not(feature = "master"))]
                 global.set_link_section(link_section.as_str());
             }
             global
@@ -73,6 +76,9 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             global.set_tls_model(self.tls_model);
         }
         if let Some(link_section) = link_section {
+            #[cfg(feature = "master")]
+            global.add_attribute(VarAttribute::Section(link_section.as_str()));
+            #[cfg(not(feature = "master"))]
             global.set_link_section(link_section.as_str());
         }
         let global_address = global.get_address(None);

--- a/src/mono_item.rs
+++ b/src/mono_item.rs
@@ -165,8 +165,10 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             fn_decl.add_attribute(FnAttribute::Visibility(base::visibility_to_gcc(visibility)));
         }
 
-        // FIXME(GuillaumeGomez): Add support for link section for `Function`.
-        // fn_decl.set_link_section(&attrs.link_section);
+        #[cfg(feature = "master")]
+        if let Some(section) = _attrs.link_section {
+            fn_decl.add_attribute(FnAttribute::Section(section.as_str()));
+        }
 
         // FIXME(antoyo): set unique comdat.
         // FIXME(antoyo): use inline attribute from there in linkage.set() above.

--- a/tests/failing-ui-tests.txt
+++ b/tests/failing-ui-tests.txt
@@ -11,7 +11,6 @@ tests/ui/mir/mir_match_guard_let_chains_drop_order.rs
 tests/ui/panic-runtime/abort-link-to-unwinding-crates.rs
 tests/ui/panic-runtime/abort.rs
 tests/ui/panic-runtime/link-to-abort.rs
-tests/ui/parser/unclosed-delimiter-in-dep.rs
 tests/ui/consts/missing_span_in_backtrace.rs
 tests/ui/drop/dynamic-drop.rs
 tests/ui/simd/issue-17170.rs
@@ -24,14 +23,10 @@ tests/ui/panic-runtime/lto-abort.rs
 tests/ui/lto/lto-thin-rustc-loads-linker-plugin.rs
 tests/ui/async-await/deep-futures-are-freeze.rs
 tests/ui/coroutine/resume-after-return.rs
-tests/ui/simd/masked-load-store.rs
 tests/ui/simd/repr_packed.rs
 tests/ui/async-await/in-trait/dont-project-to-specializable-projection.rs
 tests/ui/coroutine/unwind-abort-mix.rs
-tests/ui/consts/issue-miri-1910.rs
 tests/ui/consts/const_cmp_type_id.rs
-tests/ui/consts/issue-94675.rs
-tests/ui/traits/const-traits/const-drop-fail.rs
 tests/ui/runtime/on-broken-pipe/child-processes.rs
 tests/ui/sanitizer/cfi/assoc-ty-lifetime-issue-123053.rs
 tests/ui/sanitizer/cfi/async-closures.rs
@@ -47,7 +42,6 @@ tests/ui/sanitizer/cfi/virtual-auto.rs
 tests/ui/sanitizer/cfi/sized-associated-ty.rs
 tests/ui/sanitizer/cfi/can-reveal-opaques.rs
 tests/ui/sanitizer/kcfi-mangling.rs
-tests/ui/delegation/fn-header.rs
 tests/ui/consts/const-eval/parse_ints.rs
 tests/ui/simd/intrinsic/generic-as.rs
 tests/ui/runtime/rt-explody-panic-payloads.rs
@@ -76,14 +70,10 @@ tests/ui/sanitizer/kcfi/fn-trait-objects.rs
 tests/ui/statics/const_generics.rs
 tests/ui/test-attrs/test-panic-while-printing.rs
 tests/ui/thir-print/offset_of.rs
-tests/ui/iterators/rangefrom-overflow-debug.rs
-tests/ui/iterators/rangefrom-overflow-overflow-checks.rs
 tests/ui/iterators/iter-filter-count-debug-check.rs
 tests/ui/eii/default/call_impl.rs
 tests/ui/asm/x86_64/global_asm_escape.rs
 tests/ui/lto/all-crates.rs
-tests/ui/traits/inheritance/self-in-supertype.rs
-tests/ui/fmt/fmt_debug/shallow.rs
 tests/ui/eii/static/cross_crate_decl.rs
 tests/ui/eii/static/cross_crate_def.rs
 tests/ui/eii/static/same_address.rs


### PR DESCRIPTION
Now that we have support for the `section` attribute, we can use it more. The `wasm` case it still not supported for now.