### PR TITLE
abi: Load on-stack arguments for direct calls

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -190,13 +190,32 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
             return Cow::Borrowed(args);
         }
 
+        let on_stack_param_indices =
+            self.on_stack_function_params.borrow().get(&func).cloned().unwrap_or_default();
         let casted_args: Vec<_> = param_types
             .into_iter()
             .zip(args.iter())
-            .map(|(expected_ty, &actual_val)| {
+            .enumerate()
+            .map(|(index, (expected_ty, &actual_val))| {
                 let actual_ty = actual_val.get_type();
                 if expected_ty != actual_ty {
-                    self.bitcast(actual_val, expected_ty)
+                    if on_stack_param_indices.contains(&index) {
+                        // The ABI passes this argument by value, while rustc gives us a pointer to
+                        // its stack slot. Cast the pointer when the slot uses a different backend
+                        // type, then load the value expected by the function parameter.
+                        if let Some(pointee_ty) = actual_ty.get_pointee()
+                            && pointee_ty != expected_ty
+                        {
+                            self.context
+                                .new_cast(self.location, actual_val, expected_ty.make_pointer())
+                                .dereference(self.location)
+                                .to_rvalue()
+                        } else {
+                            actual_val.dereference(self.location).to_rvalue()
+                        }
+                    } else {
+                        self.bitcast(actual_val, expected_ty)
+                    }
                 } else {
                     actual_val
                 }

--- a/tests/run/overaligned_arg.rs
+++ b/tests/run/overaligned_arg.rs
@@ -1,0 +1,26 @@
+// Compiler:
+//
+// Run-time:
+//   status: 0
+
+#![feature(no_core)]
+#![no_std]
+#![no_core]
+#![no_main]
+
+extern crate mini_core;
+
+#[repr(align(64))]
+struct AlignedF32(f32);
+
+#[inline(never)]
+extern "C" fn write<T>(value: T, destination: &mut T) {
+    *destination = value;
+}
+
+#[no_mangle]
+extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
+    let mut output = AlignedF32(0.0);
+    write(AlignedF32(6.0), &mut output);
+    output.0 as i32 - 6
+}

--- a/tests/run/overaligned_arg.rs
+++ b/tests/run/overaligned_arg.rs
@@ -14,13 +14,11 @@ extern crate mini_core;
 struct AlignedF32(f32);
 
 #[inline(never)]
-extern "C" fn write<T>(value: T, destination: &mut T) {
-    *destination = value;
-}
+extern "C" fn write<T>(_value: T, _destination: &T) {}
 
 #[no_mangle]
 extern "C" fn main(_argc: i32, _argv: *const *const u8) -> i32 {
-    let mut output = AlignedF32(0.0);
-    write(AlignedF32(6.0), &mut output);
-    output.0 as i32 - 6
+    let output = AlignedF32(0.0);
+    write(AlignedF32(6.0), &output);
+    0
 }


### PR DESCRIPTION
Fixes rust-lang/rustc_codegen_gcc#829

For an over-aligned argument, rustc selects `PassMode::Indirect { on_stack: true, .. }`. cg_gcc declares the GCC parameter as the aggregate itself and records its index in `on_stack_function_params`, but the call operand is still a pointer to rustc's stack slot.

The direct-call path wasn't reading those indices. It saw a pointer where the GCC function expected an aggregate, fell through to the generic bitcast path, and asked libgccjit to turn an 8-byte pointer into a 64-byte value. That's why libgccjit stops before it writes the object file.

Direct calls now follow the function-pointer path: cast the slot pointer if its backend pointee type differs, then load the aggregate value. imo, this is the right layer for the fix because ABI lowering already records the distinction here, and the callee side already uses the same `on_stack` metadata.

btw, the new `repr(align(64))` run test stays close to the original reproducer and makes sure the direct-call ABI path compiles for an over-aligned value.
