### PR TITLE
int: implement signed comparison for unsigned integers

### DIFF
--- a/src/int.rs
+++ b/src/int.rs
@@ -462,9 +462,15 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
                     lhs_high = self.context.new_cast(self.location, lhs_high, unsigned_type);
                     rhs_high = self.context.new_cast(self.location, rhs_high, unsigned_type);
                 }
-                // FIXME(antoyo): we probably need to handle signed comparison for unsigned
-                // integers.
-                _ => (),
+                IntPredicate::IntSGT
+                | IntPredicate::IntSGE
+                | IntPredicate::IntSLT
+                | IntPredicate::IntSLE => {
+                    let signed_type = native_int_type.to_signed(self.cx);
+                    lhs_high = self.context.new_cast(self.location, lhs_high, signed_type);
+                    rhs_high = self.context.new_cast(self.location, rhs_high, signed_type);
+                }
+                IntPredicate::IntEQ | IntPredicate::IntNE => (),
             }
 
             let condition = self.context.new_comparison(
@@ -602,9 +608,17 @@ impl<'a, 'gcc, 'tcx> Builder<'a, 'gcc, 'tcx> {
                         rhs = self.context.new_cast(self.location, rhs, unsigned_type);
                     }
                 }
-                // FIXME(antoyo): we probably need to handle signed comparison for unsigned
-                // integers.
-                _ => (),
+                IntPredicate::IntSGT
+                | IntPredicate::IntSGE
+                | IntPredicate::IntSLT
+                | IntPredicate::IntSLE => {
+                    if !a_type.is_vector() {
+                        let signed_type = a_type.to_signed(self.cx);
+                        lhs = self.context.new_cast(self.location, lhs, signed_type);
+                        rhs = self.context.new_cast(self.location, rhs, signed_type);
+                    }
+                }
+                IntPredicate::IntEQ | IntPredicate::IntNE => (),
             }
             self.context.new_comparison(self.location, op.to_gcc_comparison(), lhs, rhs)
         }

--- a/tests/run/int.rs
+++ b/tests/run/int.rs
@@ -319,4 +319,29 @@ fn main() {
         const VAL5: T = 73236519889708027473620326106273939584_i128;
         check_ops128!();
     }
+
+    {
+        #[allow(dead_code)]
+        #[repr(u8)]
+        enum Inner {
+            L0 = 0,
+            H255 = 255,
+        }
+        #[allow(dead_code)]
+        enum O {
+            A(Inner),
+            B,
+            C,
+        }
+
+        #[inline(never)]
+        fn which(o: &O) -> &'static str {
+            match o {
+                O::A(_) => "a",
+                O::B => "b",
+                O::C => "c",
+            }
+        }
+        assert_eq!(which(black_box(&O::A(Inner::H255))), "a");
+    }
 }


### PR DESCRIPTION
Implement signed comparison for unsigned integers, which is very similar to unsigned integers but uses `to_signed()` rather than `to_unsigned()`. This fixes a case where niche optimization causes the discriminant to sometimes compare signed and unsigned values.

This was caught when running a test suite for an embedded device compiled under the gcc backend. A reproducer when compiling under -O for x86-64 is:

```rust
use std::hint::black_box;

#[repr(u8)]
enum Inner { L0 = 0, H255 = 255 }
enum O { A(Inner), B, C }

#[inline(never)]
fn which(o: &O) -> &'static str {
    match o { O::A(_) => "a", O::B => "b", O::C => "c" }
}

fn main() {
    assert_eq!(which(black_box(&O::A(Inner::H255))), "a"); // 0xFF
    println!("all ok");
}
```

The problem only shows up with `-O`, not by default.

```
thread 'main' (1223) panicked at /home/seancross/work/testcase/testcase-3.rs:13:5:
assertion `left == right` failed
  left: "c"
 right: "a"
```