### PR TITLE
asm: seed the in_value for inout

### DIFF
--- a/src/asm.rs
+++ b/src/asm.rs
@@ -291,7 +291,9 @@ impl<'a, 'gcc, 'tcx> AsmBuilderMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
                         out_place,
                     });
 
-                    if !readwrite {
+                    if readwrite {
+                        self.llbb().add_assignment(None, tmp_var, in_value.immediate());
+                    } else {
                         let out_gcc_idx = outputs.len() - 1;
                         let constraint = Cow::Owned(out_gcc_idx.to_string());
 

--- a/tests/run/asm.rs
+++ b/tests/run/asm.rs
@@ -252,6 +252,22 @@ fn asm() {
         );
     }
 
+    // Make sure the input value from inout is assigned to the input value
+    unsafe {
+        // Use a very distinctive value unlikely to live in any register.
+        let input: u64 = 0x1234567890ABCDEF;
+        let mut output: u64;
+
+        asm!(
+            "push {1}",
+            "pop   {0}",
+            out(reg) output,
+            inout(reg) input => _,
+        );
+
+        assert_eq!(output, 0x1234567890ABCDEF);
+    }
+
     asm_goto_test(0);
 }
 


### PR DESCRIPTION
When performing an "inout" operation, the "in" value isn't assigned. This results in incorrect asm being generated. Make sure the value is assigned to the input register.