### PR TITLE
Only emit -fno-asynchronous-unwind-tables when we should not emit unwind tables

### DIFF
--- a/src/gcc_util.rs
+++ b/src/gcc_util.rs
@@ -157,8 +157,9 @@ pub fn new_context<'gcc>(sess: &Session) -> Context<'gcc> {
             version,
         ));
     }
-    // FIXME(antoyo): check if this should only be added when using -Cforce-unwind-tables=n.
-    context.add_command_line_option("-fno-asynchronous-unwind-tables");
+    if !sess.must_emit_unwind_tables() {
+        context.add_command_line_option("-fno-asynchronous-unwind-tables");
+    }
 
     if sess.panic_strategy().unwinds() {
         context.add_command_line_option("-fexceptions");


### PR DESCRIPTION
The UI test `tests/ui/panics/panic-abort-backtrace-without-debuginfo.rs` will pass thanks to this fix on the next sync since https://github.com/rust-lang/rust/pull/160306 is merged.