### PR TITLE
Fix two broken links in the docs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -178,7 +178,7 @@ $ LIBRARY_PATH="[gcc-path value]" LD_LIBRARY_PATH="[gcc-path value]" rustc +$(ca
 More specific documentation is available in the [`doc`](./doc) folder:
 
  * [Common errors](./doc/errors.md)
- * [Debugging GCC LTO](./doc/debugging-gcc-lto.md)
+ * [Debugging](./doc/debugging.md)
  * [Debugging libgccjit](./doc/debugging-libgccjit.md)
  * [Git subtree sync](./doc/subtree.md)
  * [List of useful commands](./doc/tips.md)

--- a/doc/tips.md
+++ b/doc/tips.md
@@ -58,7 +58,7 @@ If you wish to build a custom sysroot, pass the path of your sysroot source to `
 ### How to generate GIMPLE
 
 If you need to check what gccjit is generating (GIMPLE), then take a look at how to
-generate it in [gimple.md](./doc/gimple.md).
+generate it in [gimple.md](./gimple.md).
 
 ### How to build a cross-compiling libgccjit
 


### PR DESCRIPTION
Two markdown links in the docs point at paths that do not exist. These are the only two broken relative links in the repository.

## `doc/tips.md`

```diff
-generate it in [gimple.md](./doc/gimple.md).
+generate it in [gimple.md](./gimple.md).
```

`tips.md` already lives in `doc/`, so `./doc/gimple.md` resolves to `doc/doc/gimple.md`. The file it wants is right next to it.

## `Readme.md`

```diff
- * [Debugging GCC LTO](./doc/debugging-gcc-lto.md)
+ * [Debugging](./doc/debugging.md)
```

`doc/debugging-gcc-lto.md` was added in 79316d4e8 ("Split Readme even further") and removed again in 79a6e4eaa ("Add documentation for stdarch tests"), which introduced the broader `doc/debugging.md` in its place. The Readme entry was not updated with it.

The GCC LTO content was not lost — it is still the first section of `doc/debugging.md` (`## How to debug GCC LTO`). Since that file now covers more than LTO, the entry is renamed rather than pointed at an anchor, which also matches `CONTRIBUTING.md:124`, where the same file is already referred to as `[Debugging](doc/debugging.md)`. The list stays in alphabetical order.

## How these were found

I resolved every relative markdown link in the repository against the tree. Of 167 files these were the only two that did not resolve, and after the change the same sweep reports none.

I also checked `rustc_codegen_gcc`'s copy inside `rust-lang/rust`: both links are broken there too, but since this repo is the subtree source (`doc/subtree.md`), fixing it here is what will carry over on the next sync.

## Disclosure

AI-assisted (Claude Code): the link sweep and this description were produced with the tool, and I verified the result myself before opening — I confirmed both targets are absent, traced the two commits that added and removed `debugging-gcc-lto.md`, checked that the LTO section survives in `doc/debugging.md`, and re-ran the sweep afterwards.

For transparency about scope: I read the [rust-lang LLM usage policy](https://forge.rust-lang.org/policies/llm-usage.html) first. Its appendix states that it applies only to `rust-lang/rust` and that other repositories in the org, and subtrees, are free to set their own policies, and I did not find a policy in this repository. I am disclosing anyway rather than treating the absence of one as permission. Happy to adjust or withdraw this if you would prefer a different standard here.
