### PR TITLE
Remove the struct layer if there is only one field

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -104,7 +104,12 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
 
             let init = crate::consts::const_alloc_to_gcc_uncached(self, alloc);
             let alloc = alloc.inner();
-            let typ = self.val_ty(init).get_aligned(alloc.align.bytes());
+
+            let mut typ = self.val_ty(init);
+            // FIXME(GuillaumeGomez): is it only structs or could be other types?
+            if typ.is_struct().is_some() {
+                typ = typ.get_aligned(alloc.align.bytes());
+            }
 
             let global = self.declare_global_with_linkage(&name, typ, GlobalKind::Internal);
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -222,12 +222,19 @@ impl<'gcc, 'tcx> CodegenCx<'gcc, 'tcx> {
             Some(kind) if !self.tcx.sess.fewer_names() => {
                 let name = self.generate_local_symbol_name(kind);
                 // FIXME(antoyo): check if it's okay that no link_section is set.
-
-                let typ = self.val_ty(cv).get_aligned(align.bytes());
+                let mut typ = self.val_ty(cv);
+                // FIXME(GuillaumeGomez): is it only structs or could be other types?
+                if typ.is_struct().is_some() {
+                    typ = typ.get_aligned(align.bytes());
+                }
                 self.declare_private_global(&name[..], typ)
             }
             _ => {
-                let typ = self.val_ty(cv).get_aligned(align.bytes());
+                let mut typ = self.val_ty(cv);
+                // FIXME(GuillaumeGomez): is it only structs or could be other types?
+                if typ.is_struct().is_some() {
+                    typ = typ.get_aligned(align.bytes());
+                }
                 self.declare_unnamed_global(typ)
             }
         };
@@ -397,8 +404,7 @@ pub(crate) fn const_alloc_to_gcc_uncached<'gcc>(
         llvals.push(cx.const_bytes(bytes));
     }
 
-    // FIXME(bjorn3) avoid wrapping in a struct when there is only a single element.
-    cx.const_struct(&llvals, true)
+    if let &[data] = &*llvals { data } else { cx.const_struct(&llvals, true) }
 }
 
 fn codegen_static_initializer<'gcc, 'tcx>(


### PR DESCRIPTION
Part of https://github.com/rust-lang/rustc_codegen_gcc/issues/643. Not marking it as a fix as the generated ASM is too ugly for me to check if it's actually better or not with this change. Gonna need to check why cg_gcc generates such ugly ASM for cstr.