### PR TITLE
Add a new environment variable for adding a custom libgccjit path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -172,6 +172,7 @@ $ LIBRARY_PATH="[gcc-path value]" LD_LIBRARY_PATH="[gcc-path value]" rustc +$(ca
  * _**CG_GCCJIT_DUMP_EVERYTHING**_: Enables dumping of all intermediate representations and passes.
  * _**CG_GCCJIT_KEEP_INTERMEDIATES**_: Keeps intermediate files generated during the compilation process.
  * _**CG_GCCJIT_VERBOSE**_: Enables verbose output from the GCC driver.
+ * _**CG_GCCJIT_SEARCH_PATH**_: Add a custom library path to look for `libgccjit.so` in
 
 ## Extra documentation
 

--- a/Readme.md
+++ b/Readme.md
@@ -172,7 +172,7 @@ $ LIBRARY_PATH="[gcc-path value]" LD_LIBRARY_PATH="[gcc-path value]" rustc +$(ca
  * _**CG_GCCJIT_DUMP_EVERYTHING**_: Enables dumping of all intermediate representations and passes.
  * _**CG_GCCJIT_KEEP_INTERMEDIATES**_: Keeps intermediate files generated during the compilation process.
  * _**CG_GCCJIT_VERBOSE**_: Enables verbose output from the GCC driver.
- * _**CG_GCCJIT_SEARCH_PATH**_: Add a custom library path to look for `libgccjit.so` in
+ * _**CG_GCCJIT_LIBRARY_PATH**_: Add a custom path to the `libgccjit` library file to load first. If the specified file wasn't found (or couldn't be loaded), then it'll automatically look through sysroot paths to find the library instead.
 
 ## Extra documentation
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,6 +220,10 @@ impl CodegenBackend for GccCodegenBackend {
             && let Ok(true) = fs::exists(custom_path)
         {
             load_libgccjit_if_needed(&PathBuf::from(custom_path));
+
+            if !gccjit::is_loaded() {
+                println!("Could not load gccjit from CG_GCCJIT_LIBRARY_PATH: {}.", custom_path);
+            }
         }
 
         // We use all_paths() instead of only path() in case the path specified by --sysroot is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ impl CodegenBackend for GccCodegenBackend {
             load_libgccjit_if_needed(&PathBuf::from(custom_path));
 
             if !gccjit::is_loaded() {
-                println!("Could not load gccjit from CG_GCCJIT_LIBRARY_PATH: {}.", custom_path);
+                println!("Could not load gccjit from CG_GCCJIT_LIBRARY_PATH: {}", custom_path);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,11 +210,16 @@ impl CodegenBackend for GccCodegenBackend {
                     lib_path.join(sess.target.llvm_target.as_ref()).join("libgccjit.so");
                 paths.push(llvm_target_path);
             }
-            if let Ok(custom_path) = env::var("CG_GCCJIT_SEARCH_PATH").as_deref() {
-                paths.push(PathBuf::from(custom_path).join("libgccjit.so"));
-            }
 
             paths
+        }
+
+        // If the user set the CG_GCCJIT_LIBRARY_PATH environment variable, then we'll load the
+        // library first from there.
+        if let Ok(custom_path) = env::var("CG_GCCJIT_LIBRARY_PATH").as_deref()
+            && let Ok(true) = fs::exists(custom_path)
+        {
+            load_libgccjit_if_needed(&PathBuf::from(custom_path));
         }
 
         // We use all_paths() instead of only path() in case the path specified by --sysroot is
@@ -231,6 +236,13 @@ impl CodegenBackend for GccCodegenBackend {
 
         if !gccjit::is_loaded() {
             let mut paths = vec![];
+
+            // Add the path from the environment variable to tell the user that we tried to load
+            // the library from there.
+            if let Ok(custom_path) = env::var("CG_GCCJIT_LIBRARY_PATH").as_deref() {
+                paths.push(PathBuf::from(custom_path));
+            }
+
             for path in sess.opts.sysroot.all_paths() {
                 for libgccjit_target_lib_file in file_paths(path, sess) {
                     paths.push(libgccjit_target_lib_file);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,11 +70,11 @@ mod type_of;
 use std::any::Any;
 use std::ffi::CString;
 use std::fmt::Debug;
-use std::fs;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
+use std::{env, fs};
 
 #[cfg(feature = "master")]
 use gccjit::TargetInfo;
@@ -210,6 +210,10 @@ impl CodegenBackend for GccCodegenBackend {
                     lib_path.join(sess.target.llvm_target.as_ref()).join("libgccjit.so");
                 paths.push(llvm_target_path);
             }
+            if let Ok(custom_path) = env::var("CG_GCCJIT_SEARCH_PATH").as_deref() {
+                paths.push(PathBuf::from(custom_path).join("libgccjit.so"));
+            }
+
             paths
         }
 


### PR DESCRIPTION
This PR adds a environment variable, that lets the user choose where should the driver look for `libgccjit` in.

This is better (in my opinion) than making a symlink in the Rust toolchain directory, because you don't have to assume which toolchain and host CPU architecture the user is using