### PR TITLE
Ignore code model setting for m68k

### DIFF
--- a/src/gcc_util.rs
+++ b/src/gcc_util.rs
@@ -204,13 +204,16 @@ pub fn new_context<'gcc>(sess: &Session) -> Context<'gcc> {
     if let Some(model) = sess.code_model() {
         use rustc_target::spec::CodeModel;
 
-        context.add_command_line_option(match model {
-            CodeModel::Tiny => "-mcmodel=tiny",
-            CodeModel::Small => "-mcmodel=small",
-            CodeModel::Kernel => "-mcmodel=kernel",
-            CodeModel::Medium => "-mcmodel=medium",
-            CodeModel::Large => "-mcmodel=large",
-        });
+        // NOTE: GCC m68k has no option for configuring the code model, so this should be ignored.
+        if sess.target.arch != Arch::M68k {
+            context.add_command_line_option(match model {
+                CodeModel::Tiny => "-mcmodel=tiny",
+                CodeModel::Small => "-mcmodel=small",
+                CodeModel::Kernel => "-mcmodel=kernel",
+                CodeModel::Medium => "-mcmodel=medium",
+                CodeModel::Large => "-mcmodel=large",
+            });
+        }
     }
 
     match sess.stack_protector() {


### PR DESCRIPTION
`m68k-unknown-none-elf`'s target spec has [the code model set to `medium`](https://github.com/rust-lang/rust/blob/main/compiler/rustc_target/src/spec/targets/m68k_unknown_none_elf.rs#L15) which causes rustc_codegen_gcc to insert `-mcmodel=medium` in the GCC command-line options. Since GCC m68k doesn't support this option, it prematurely errors with `libgccjit.so: error: unrecognized command-line option '-mcmodel=medium'`

This PR fixes the issue by making rustc_codegen_gcc ignore the code model setting if the target architecture is m68k